### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ html.is-animating .transition-main {
 }
 
 /*
-* The animation for the fragment rule named "users"
+* The animation when filtering users
 */
 #users.is-changing {
   transition: opacity 250ms;
@@ -138,8 +138,8 @@ export type PluginOptions = {
 
 The rules that define whether a visit will be considered a fragment visit. Each rule consists of
 mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as well as an optional
-`name` of this rule to allow precise styling. The from/to patterns are converted to regular
-expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
+`name` of this rule to allow scoped styling. The from/to patterns are interpreted and follow the
+syntax established by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ involved and swup doesn't know which page the overlay was opened from.
 Use the `data-swup-fragment-url` attribute to uniquely identify fragments.
 
 In scenarios where overlays are rendered on top of other content, leaving or closing the overlay to
-the exact same URL it was opened from should ideally not update the content below the overlay as
+the same URL it was opened from should ideally not update the content below the overlay as
 nothing has changed. The fragment plugin will normally do that by keeping track of URLs. However,
 when swup was initialized on a subpage with a visible overlay, the plugin doesn't know which URL
 the overlaid content corresponds to. Hence, we need to tell it manually so it can ignore content

--- a/README.md
+++ b/README.md
@@ -10,13 +10,28 @@ https://swup-fragment-plugin.netlify.app
 
 ## Installation
 
-```shell
-npm i @swup/fragment-plugin --save
+Install the plugin from npm and import it into your bundle.
+
+```bash
+npm install @swup/fragment-plugin
 ```
 
-## Simple Example
+```js
+import SwupFragmentPlugin from '@swup/fragment-plugin';
+```
 
-Suppose you have an endpoint `/users/` on your site that lists a bunch of users:
+Or include the minified production file from a CDN:
+
+```html
+<script src="https://unpkg.com/@swup/fragment-plugin@1"></script>
+```
+
+## Example
+
+Suppose you have a route `/users/` on your site that renders a list of users. A filter UI
+allows selecting criteria for filtering the user list. Selecting a filter ideally won't
+trigger a full page reload — the only thing that has changed is the list of users itself. This is
+where the Fragment Plugin comes in.
 
 ```html
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -30,10 +30,15 @@ Or include the minified production file from a CDN:
 
 ## Example
 
-Suppose you have a route `/users/` on your site that renders a list of users. A filter UI
-allows selecting criteria for filtering the user list. Selecting a filter ideally won't
-trigger a full page reload — the only thing that has changed is the list of users itself. This is
-where the Fragment Plugin comes in.
+The two prime use cases are content filters and detail overlays.
+
+### Content filter: only update results
+
+A website has a page `/users/` that displays a list of users. Above the user list, there
+is a filter UI to choose which users to display. Selecting a filter will trigger a normal page visit
+to the narrowed-down user list, e.g. `/users/filter/x/`. The only part that has changed is the
+list of users, so that's what we'd like to replace and animate instead of the whole content
+container. The Fragment Plugin automates this process of selectively updating page fragments.
 
 ```html
 <!DOCTYPE html>
@@ -41,35 +46,33 @@ where the Fragment Plugin comes in.
   <title>Our Users — My Website</title>
 </html>
 <body>
-  <div>My Website</div>
+  <header>My Website</header>
   <nav><!-- ... --></nav>
-  <div id="swup" class="transition-main">
+  <main id="swup" class="transition-main">
     <h1>Our Users</h1>
-    <main id="users" class="transition-users">
-      <!-- A list of filters for the users -->
-      <ul>
-        <a href="/users/filter/1/">Filter 1</a> <!-- Clicking here should update the list below -->
-        <a href="/users/filter/2/">Filter 2</a>
-        <a href="/users/filter/3/">Filter 2</a>
-      </ul>
-      <!-- The list of users, different for each filter -->
-      <ul>
-        <li><a href="/user/1/">User 1</a></li>
-        <li><a href="/user/2/">User 2</a></li>
-        <li><a href="/user/3/">User 3</a></li>
-      </ul>
-    </main>
-  </div>
+    <!-- A list of filters for the users: selecting one will update the list below -->
+    <ul>
+      <a href="/users/filter/1/">Filter 1</a>
+      <a href="/users/filter/2/">Filter 2</a>
+      <a href="/users/filter/3/">Filter 2</a>
+    </ul>
+    <!-- The list of users, different for each filter -->
+    <ul id="users" class="transition-users">
+      <li><a href="/user/1/">User 1</a></li>
+      <li><a href="/user/2/">User 2</a></li>
+      <li><a href="/user/3/">User 3</a></li>
+    </ul>
+  </main>
 </body>
 ```
 
-You can tell the Fragment Plugin to **only** update the `#users` list when clicking one of the filters:
+Using the Fragment Plugin, we can **only** update the `#users` list when clicking one of the filters.
+The plugin expects an array of rules to recognize and handle fragment visits.
 
 ```js
 const swup = new Swup({
   plugins: [
     new SwupFragmentPlugin({
-      // The plugin expects an array of rules:
       rules: [
         {
           from: '/users/:filter?',
@@ -83,13 +86,15 @@ const swup = new Swup({
 });
 ```
 
+## How it works
+
 When the current visit matches a fragment rule, the plugin will:
 
 - **update** only the contents of the elements defined in the rule's `fragment` key
-- **not update** the default content [containers](https://swup.js.org/options/#containers) of all other visits
-- **preserve** the current scroll position upon navigation
+- **not update** the default content [containers](https://swup.js.org/options/#containers) replaced on all other visits
 - **wait** for CSS transitions on those fragment elements using [scoped animations](https://swup.js.org/options/#animation-scope)
-- add a `to-route-name` class the the elements if the current `rule` has a `name`  key
+- add a `to-fragment-[name]` class to the elements if the current `rule` has a `name`  key
+- **preserve** the current scroll position upon navigation
 
 ```css
 /*

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When a visit is determined to be a fragment visit, the plugin will:
 
 ### Content filter: only update list of results
 
-A website has a page `/users/` that displays a list of users. Above the user list, there
+Imagine a website with a `/users/` page that displays a list of users. Above the user list, there
 is a filter UI to choose which users to display. Selecting a filter will trigger a visit
 to the narrowed-down user list at `/users/filter/x/`. The only part that has changed is the
 list of users, so that's what we'd like to replace and animate instead of the whole content
@@ -136,7 +136,7 @@ export type PluginOptions = {
 
 ### rules
 
-The rules that define whether a visit will be considered as a fragment visit. Each rule consists of
+The rules that define whether a visit will be considered a fragment visit. Each rule consists of
 mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as well as an optional
 `name` of this rule to allow precise styling. The from/to patterns are converted to regular
 expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).

--- a/README.md
+++ b/README.md
@@ -206,17 +206,48 @@ Type: `boolean`. Set to `true` for debug information in the console. Defaults to
 - The rule's `from` and `to` patterns are converted to a regular expression by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp). If you want to create an either/or pattern, you can also provide an array of patterns, for example `['/users/', '/users/filter/:filter']`
 - If no rule matches the current visit, the default content containers defined in swup's options will be replaced
 
-## Fragment containers
+## How fragment containers are found
 
 - The `fragments` of the matching rule need to be present in **both the current and the incoming document**
 - For each selector in the `fragments` array, the **first** matching element in the DOM will be selected
 - The plugin will check if a fragment already matches the new URL before replacing it
 
-## DOM API
+## Advanced use cases
 
-### `[data-swup-fragment-url]` @TODO
+Creating the rules for your fragment visits should be enough to enable dynamic updates on most
+sites. However, there are some advanced use cases that require adding certain attributes to the
+fragments themselves or to links on the page. These tend to be situations where overlays are
+involved and swup doesn't know which page the overlay was opened from.
 
-If you provide this attribute on one of your fragments from the server, you can tell the plugin to persist that fragment when navigating to the given URL. For example: `[data-swup-fragment-url="/users/"]`
+### Fragment URL
+
+Use the `data-swup-fragment-url` attribute to uniquely identify fragments.
+
+In scenarios where overlays are rendered on top of other content, leaving or closing the overlay to
+the exact same URL it was opened from should ideally not update the content below the overlay as
+nothing has changed. The fragment plugin will normally do that by keeping track of URLs. However,
+when swup was initialized on a subpage with a visible overlay, the plugin doesn't know which URL
+the overlaid content corresponds to. Hence, we need to tell it manually so it can ignore content
+updates without changes.
+
+```html
+<section data-swup-fragment-url="/users/">
+  <ul>
+    <li>User 1</li>
+    <li>User 2</li>
+    <li>User 3</li>
+  </ul>
+</section>
+
+<article data-swup-fragment-url="/user/1/">
+  <h1>User 1</h1>
+  <p>Lorem ipsum dolor sit amet...</p>
+</article>
+```
+
+### Link to fragment
+
+In the previous
 
 ### `[data-swup-link-to-fragment]` @TODO
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ updates without changes.
     <li>User 3</li>
   </ul>
 </section>
-
 <article data-swup-fragment-url="/user/1/">
   <h1>User 1</h1>
   <p>Lorem ipsum dolor sit amet...</p>
@@ -247,8 +246,27 @@ updates without changes.
 
 ### Link to fragment
 
-In the previous
+Use the `data-swup-link-to-fragment` attribute to automatically update links pointing to a fragment.
 
-### `[data-swup-link-to-fragment]` @TODO
+Consider again an overlay rendered on top of other content. To implement a close button for that
+overlay, we could ideally point a link at the URL of the content where the overlay was closed. The
+fragment plugin will then handle the animation and replacing of the overlay. However, knowing
+where to point that link requires knowing where the current overlay was opened from.
 
-Tell a link to be synced to a fragment's URL on every visit.
+This attribute automates that by keeping the `href` attribute of any link in sync with the currently
+tracked URL of the fragment matching that selector. The code below will make sure the close button
+will always point at the last known URL of the `#list` fragment to allow easy closing of the overlay.
+
+```html
+<section id="list">
+  <ul>
+    <li>User 1</li>
+    <li>User 2</li>
+    <li>User 3</li>
+  </ul>
+</section>
+<article id="overlay">
+  <a href="" data-swup-link-to-fragment="#list">Close</a>
+  <h1>User 1</h1>
+  <p>Lorem ipsum dolor sit amet...</p>
+</article>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 A [swup](https://swup.js.org) plugin for selectively updating dynamic fragments.
 
-⚠️ **Please Note**: This plugin is not stable yet and should not be used in production.
+- Replace dynamic fragments instead of swup's default containers, based on custom rules
+- Whereas content containers typically encompass the main content areas, fragments focus on smaller more dynamic elements within those containers, holding atomic pieces of information
+- Useful for scenarios like filter results or detail overlays, where only certain parts of the page need refreshing on each visit
 
-### Demo
+## Demo
 
-https://swup-fragment-plugin.netlify.app
+[See the plugin in action](https://swup-fragment-plugin.netlify.app) in this interactive demo.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or include the minified production file from a CDN:
 
 ## How it works
 
-When a visit is determinded to be a fragment visit, the plugin will:
+When a visit is determined to be a fragment visit, the plugin will:
 
 - **update only** the contents of the elements defined in the rule's `fragments`
 - **not update** the default content [containers](https://swup.js.org/options/#containers) replaced on all other visits

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ export type PluginOptions = {
 ### rules
 
 The rules that define whether a visit will be considered as a fragment visit.
+```js
+{
+  rules: [
+    {
+      from: '/users/:filter?',
+      to: '/users/:filter?',
+      fragments: ['#users'],
+      name: 'list'
+    }
+  ]
+}
+```
 
 Each rule consists of mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as
 well as an optional `name` of this rule to allow precise styling.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 }
 ```
 
+### (List)
+
+- `from`, required, `string | string[]` — The pattern(s) to match against the previous URL
+- `to`, required, `string | string[]` — The pattern(s) to match against the next URL
+- `fragments`, required, `string[]` — Selectors of containers to be replaced if the visit matches
+- `name`, optional, `string` — A name for this rule to allow scoped styling, ideally in kebab-case
+
 ### (Table)
 
 |    Param    | Required |         Type         |                             Description                             |
@@ -162,13 +169,6 @@ expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 | `to`        | required | `string \| string[]` | The pattern(s) to match against the next URL                        |
 | `fragments` | required | `string[]`           | Selectors of containers to be replaced if the visit matches         |
 | `name`      | optional | `string`             | A name for this rule to allow scoped styling, ideally in kebab-case |
-
-### (List)
-
-- `from`, required, `string | string[]` — The pattern(s) to match against the previous URL
-- `to`, required, `string | string[]` — The pattern(s) to match against the next URL
-- `fragments`, required, `string[]` — Selectors of containers to be replaced if the visit matches
-- `name`, optional, `string` — A name for this rule to allow scoped styling, ideally in kebab-case
 
 ### (Headings)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ html.is-animating .transition-main {
 export type PluginOptions = {
   rules: Array<{
     from: string | string[];
-    from: string | string[];
+    to: string | string[];
     fragments: string[];
     name?: string;
   }>;

--- a/README.md
+++ b/README.md
@@ -171,9 +171,15 @@ matches the above patterns.
 
 Optional. Type: `string`. An optional name for this rule to allow scoped styling, ideally in kebab-case.
 
-#### debug
+### debug
 
-Type: `boolean`. Set this to `true` for debug information in the console. Defaults to `false`.
+Type: `boolean`. Set to `true` for debug information in the console. Defaults to `false`.
+
+```js
+{
+  debug: true
+}
+```
 
 ## How rules are matched
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ const swup = new Swup({
   ]
 });
 ```
-When a rule matches for a visit, the plugin will
 
-- **change** the [`containers`](https://swup.js.org/options/#containers) to the rule's `fragments`
-- **preserve** the current scroll position
-- set the [`animationScope`](https://swup.js.org/options/#animation-scope) to `containers` for **scoped animations** on the fragments only
-- if the current `rule` has a `name` (e.g. "my-route"), that will be reflected as a class `.to-my-route` on the fragment.
+When the current visit matches a fragment rule, the plugin will:
+
+- **update** only the contents of the elements defined in the rule's `fragment` key
+- **not update** the default content [containers](https://swup.js.org/options/#containers) of all other visits
+- **preserve** the current scroll position upon navigation
+- **wait** for CSS transitions on those fragment elements using [scoped animations](https://swup.js.org/options/#animation-scope)
+- add a `to-route-name` class the the elements if the current `rule` has a `name`  key
 
 ```css
 /*
@@ -100,8 +102,9 @@ html.is-changing .transition-main {
 html.is-animating .transition-main {
   opacity: 0;
 }
+
 /*
-* The transitions for the named rule "filterUsers"
+* The transitions for the named rule "users"
 */
 .transition-users.is-changing {
   transition: opacity 250ms;
@@ -111,41 +114,45 @@ html.is-animating .transition-main {
 }
 ```
 
-## JavaScript API
+## Options
 
-### Rules
+### rules
 
-Each rule consist of these properties:
+The rules that define whether a visit will be considered as a fragment visit.
+
+Each rule consists of mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as
+well as an optional `name` of this rule.
 
 #### `from: string | string[]`
 
-The path before the current visit. Will be converted to a `RegExp`.
+The pattern to match against the previous URL. Converted to a regular expression via
+[path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 
 #### `to: string | string[]`
 
-The new path of the current visit. Will be converted to a `RegExp`.
+The pattern or regular expression to match against the next page.
 
 #### `fragments: string[]`
 
-An array of selectors for fragments that should be replaced if the rule matches the current visit
+An array of selectors for fragments that should be replaced if the visit matches the above patterns.
 
 #### `name: string` (optional)
 
-A name for the rule, for scoped styling.
+An optional name for this rule to allow scoped styling.
 
-### Rule matching logic
+### How rules are matched
 
 - The first matching rule in your `rules` array will be used for the current visit
 - If no `rule` matches the current visist, the default `swup.containers` will be replaced
-- `rule.from` and `rule.to` are converted to a regular expression by [pathToRegexp](https://github.com/pillarjs/path-to-regexp). If you want to create an either/or-regex, you can also provide an array of paths, for example `['/users/', '/users/filter/:filter']`
+- `rule.from` and `rule.to` are converted to a regular expression by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp). If you want to create an either/or pattern, you can also provide an array of patterns, for example `['/users/', '/users/filter/:filter']`
 
-### Fragments
+### Fragment selectors
 
 - The `rule.fragments` selectors from the matching `rule` need to be present in **both the current and the incoming document**
 - For each `rule.fragments` entry, the **first** matching element in the DOM will be selected
 - The plugin will check if a fragment already matches the new URL before replacing it
 
-## DOM API
+## Markup
 
 - `[data-swup-fragment-url]` @TODO
 - `[data-swup-link-to-fragment]` @TODO

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [swup](https://swup.js.org) plugin for selectively updating dynamic fragments.
 ## Use cases
 
 Both of the following two scenarios require updating only a small content fragment instead of
-performing a full page transition.
+performing a full page transition:
 
 - a filter UI that live-updates its list of results on every interaction
 - a detail overlay that shows on top of the currently open content
@@ -49,7 +49,7 @@ When a visit is determined to be a fragment visit, the plugin will:
 
 ## Example
 
-### Content filter: only update list of results
+### Content filter: only update a list of results
 
 Imagine a website with a `/users/` page that displays a list of users. Above the user list, there
 is a filter UI to choose which users to display. Selecting a filter will trigger a visit
@@ -79,7 +79,7 @@ container.
 ```
 
 Using the Fragment Plugin, we can update **only** the `#users` list when clicking one of the filters.
-The plugin expects an array of rules to recognize and handle fragment visits.
+The plugin expects an array of rules to recognize and handle fragment visits:
 
 ```js
 const swup = new Swup({
@@ -95,7 +95,7 @@ const swup = new Swup({
 });
 ```
 
-Now you can add custom animations for your fragment rule:
+Now we can add custom animations for our fragment rule:
 
 ```css
 /*
@@ -137,9 +137,10 @@ export type PluginOptions = {
 ### rules
 
 The rules that define whether a visit will be considered a fragment visit. Each rule consists of
-mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as well as an optional
-`name` of this rule to allow scoped styling. The from/to patterns are interpreted and follow the
-syntax established by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
+mandatory `from` and `to` URL paths, an array `fragments` of selectors, as well as an optional
+`name` of this rule to allow scoped styling.
+
+The rule's `from`/`to` paths are converted to a regular expression by [path-to-regexp](https://github.com/pillarjs/path-to-regexp) and matched against the current browser URL. If you want to create an either/or path, you can also provide an array of paths, for example `['/users/', '/users/filter/:filter']`.
 
 ```js
 {
@@ -154,41 +155,12 @@ syntax established by [path-to-regexp](https://www.npmjs.com/package/path-to-reg
 }
 ```
 
-### (List)
-
-- `from`, required, `string | string[]` — The pattern(s) to match against the previous URL
-- `to`, required, `string | string[]` — The pattern(s) to match against the next URL
-- `fragments`, required, `string[]` — Selectors of containers to be replaced if the visit matches
-- `name`, optional, `string` — A name for this rule to allow scoped styling, ideally in kebab-case
-
-### (Table)
-
 |    Param    | Required |         Type         |                             Description                             |
 | ----------- | -------- | -------------------- | ------------------------------------------------------------------- |
-| `from`      | required | `string \| string[]` | The pattern(s) to match against the previous URL                    |
-| `to`        | required | `string \| string[]` | The pattern(s) to match against the next URL                        |
+| `from`      | required | `string \| string[]` | The path(s) to match against the previous URL                    |
+| `to`        | required | `string \| string[]` | The path(s) to match against the next URL                        |
 | `fragments` | required | `string[]`           | Selectors of containers to be replaced if the visit matches         |
 | `name`      | optional | `string`             | A name for this rule to allow scoped styling, ideally in kebab-case |
-
-### (Headings)
-
-#### from
-
-**Required**. Type: `string | string[]`. The pattern to match against the previous URL. Converted
-to a regular expression via [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
-
-#### to
-
-**Required**. Type: `string | string[]`. The pattern or regular expression to match against the next page.
-
-#### fragments
-
-**Required**. Type: `string[]`. An array of selectors for fragments to be replaced if the visit
-matches the above patterns.
-
-#### name
-
-Optional. Type: `string`. An optional name for this rule to allow scoped styling, ideally in kebab-case.
 
 ### debug
 
@@ -203,7 +175,6 @@ Type: `boolean`. Set to `true` for debug information in the console. Defaults to
 ## How rules are matched
 
 - The first matching rule in your `rules` array will be used for the current visit
-- The rule's `from` and `to` patterns are converted to a regular expression by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp). If you want to create an either/or pattern, you can also provide an array of patterns, for example `['/users/', '/users/filter/:filter']`
 - If no rule matches the current visit, the default content containers defined in swup's options will be replaced
 
 ## How fragment containers are found
@@ -231,14 +202,14 @@ the overlaid content corresponds to. Hence, we need to tell it manually so it ca
 updates without changes.
 
 ```html
-<section data-swup-fragment-url="/users/">
+<section id="list" data-swup-fragment-url="/users/">
   <ul>
     <li>User 1</li>
     <li>User 2</li>
     <li>User 3</li>
   </ul>
 </section>
-<article data-swup-fragment-url="/user/1/">
+<article id="overlay">
   <h1>User 1</h1>
   <p>Lorem ipsum dolor sit amet...</p>
 </article>
@@ -253,12 +224,12 @@ overlay, we could ideally point a link at the URL of the content where the overl
 fragment plugin will then handle the animation and replacing of the overlay. However, knowing
 where to point that link requires knowing where the current overlay was opened from.
 
-This attribute automates that by keeping the `href` attribute of any link in sync with the currently
-tracked URL of the fragment matching that selector. The code below will make sure the close button
-will always point at the last known URL of the `#list` fragment to allow easy closing of the overlay.
+`data-swup-link-to-fragment` automates that by keeping the `href` attribute of a link in sync with the currently
+tracked URL of the fragment matching the selector provided by the attribute. The code below will make sure the close button
+will always point at the last known URL of the `#list` fragment to allow seamlessly closing the overlay. To keep your markup semantic and accessible, you should still provide a default value for the `href` attribute of the link.
 
 ```html
-<section id="list">
+<section id="list" data-swup-fragment-url="/users/">
   <ul>
     <li>User 1</li>
     <li>User 2</li>
@@ -266,7 +237,9 @@ will always point at the last known URL of the `#list` fragment to allow easy cl
   </ul>
 </section>
 <article id="overlay">
-  <a href="" data-swup-link-to-fragment="#list">Close</a>
+  <a href="/users/" data-swup-link-to-fragment="#list">Close</a>
   <h1>User 1</h1>
   <p>Lorem ipsum dolor sit amet...</p>
 </article>
+```
+

--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ export type PluginOptions = {
 
 ### rules
 
-The rules that define whether a visit will be considered as a fragment visit.
+The rules that define whether a visit will be considered as a fragment visit. Each rule consists of
+mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as well as an optional
+`name` of this rule to allow precise styling. The from/to patterns are converted to regular
+expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
+
 ```js
 {
   rules: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swup Fragment Plugin
 
-Replace page fragments instead of swup's default `containers`, based on user-defined rules
+A [swup](https://swup.js.org) plugin for selectively updating dynamic fragments.
 
 ⚠️ **Please Note**: This plugin is not stable yet and should not be used in production.
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ updates without changes.
 Use the `data-swup-link-to-fragment` attribute to automatically update links pointing to a fragment.
 
 Consider again an overlay rendered on top of other content. To implement a close button for that
-overlay, we could ideally point a link at the URL of the content where the overlay was closed. The
+overlay, we could ideally point a link at the URL of the content where the overlay is closed. The
 fragment plugin will then handle the animation and replacing of the overlay. However, knowing
 where to point that link requires knowing where the current overlay was opened from.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A [swup](https://swup.js.org) plugin for selectively updating dynamic fragments.
 
 ## Use cases
 
-Imagine the two scenarios below. Both of these require updating only a small content fragment instead
-of performing a full page transition.
+Both of the following two scenarios require updating only a small content fragment instead of
+performing a full page transition.
 
 - a filter UI that live-updates its list of results on every interaction
 - a detail overlay that shows on top of the currently open content
@@ -34,6 +34,17 @@ Or include the minified production file from a CDN:
 ```html
 <script src="https://unpkg.com/@swup/fragment-plugin@1"></script>
 ```
+
+## How it works
+
+When a visit is determinded to be a fragment visit, the plugin will:
+
+- **update only** the contents of the elements defined in the rule's `fragments`
+- **not update** the default content [containers](https://swup.js.org/options/#containers) replaced on all other visits
+- **wait** for CSS transitions on those fragment elements using [scoped animations](https://swup.js.org/options/#animation-scope)
+- **preserve** the current scroll position upon navigation
+- add a `to-fragment-[name]` class to the elements if the current `rule` has a `name`  key
+- ignore the visit completely if a fragment already matches the current visit's URL
 
 ## Example
 
@@ -83,17 +94,6 @@ const swup = new Swup({
 });
 ```
 
-## How it works
-
-When the current visit matches a fragment rule, the plugin will:
-
-- **update** only the contents of the elements defined in the rule's `fragments`
-- **not update** the default content [containers](https://swup.js.org/options/#containers) replaced on all other visits
-- **wait** for CSS transitions on those fragment elements using [scoped animations](https://swup.js.org/options/#animation-scope)
-- add a `to-fragment-[name]` class to the elements if the current `rule` has a `name`  key
-- **preserve** the current scroll position upon navigation
-- If a fragment already matches the current visit's URL, it **will be ignored for that visit**
-
 Now you can add custom animations for your fragment rule:
 
 ```css
@@ -138,49 +138,40 @@ export type PluginOptions = {
 The rules that define whether a visit will be considered as a fragment visit.
 
 Each rule consists of mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as
-well as an optional `name` of this rule.
+well as an optional `name` of this rule to allow precise styling.
 
 #### from
 
-**Required**. Type: `string | string[]`
-
-The pattern to match against the previous URL. Converted to a regular expression via
-[path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
+**Required**. Type: `string | string[]`. The pattern to match against the previous URL. Converted
+to a regular expression via [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 
 #### to
 
-**Required**. Type: `string | string[]`
-
-The pattern or regular expression to match against the next page.
+**Required**. Type: `string | string[]`. The pattern or regular expression to match against the next page.
 
 #### fragments
 
-**Required**. Type: `string[]`
-
-An array of selectors for fragments that should be replaced if the visit matches the above patterns.
+**Required**. Type: `string[]`. An array of selectors for fragments to be replaced if the visit
+matches the above patterns.
 
 #### name
 
-Optional. Type: `string`
-
-An optional name for this rule to allow scoped styling, ideally in kebab-case.
+Optional. Type: `string`. An optional name for this rule to allow scoped styling, ideally in kebab-case.
 
 #### debug
 
-Type: `boolean`, default: `false`
-
-Set this to `true` for debug information in the console.
+Type: `boolean`. Set this to `true` for debug information in the console. Defaults to `false`.
 
 ## How rules are matched
 
 - The first matching rule in your `rules` array will be used for the current visit
-- If no `rule` matches the current visist, the default `swup.containers` will be replaced
-- `rule.from` and `rule.to` are converted to a regular expression by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp). If you want to create an either/or pattern, you can also provide an array of patterns, for example `['/users/', '/users/filter/:filter']`
+- The rule's `from` and `to` patterns are converted to a regular expression by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp). If you want to create an either/or pattern, you can also provide an array of patterns, for example `['/users/', '/users/filter/:filter']`
+- If no rule matches the current visit, the default content containers defined in swup's options will be replaced
 
-## Fragment selectors
+## Fragment containers
 
-- The `rule.fragments` elements from the matching `rule` need to be present in **both the current and the incoming document**
-- For each `rule.fragments` entry, the **first** matching element in the DOM will be selected
+- The `fragments` of the matching rule need to be present in **both the current and the incoming document**
+- For each selector in the `fragments` array, the **first** matching element in the DOM will be selected
 - The plugin will check if a fragment already matches the new URL before replacing it
 
 ## DOM API

--- a/README.md
+++ b/README.md
@@ -154,8 +154,23 @@ expressions by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).
 }
 ```
 
-Each rule consists of mandatory `from` and `to` URL patterns, an array `fragments` of selectors, as
-well as an optional `name` of this rule to allow precise styling.
+### (Table)
+
+|    Param    | Required |         Type         |                             Description                             |
+| ----------- | -------- | -------------------- | ------------------------------------------------------------------- |
+| `from`      | required | `string \| string[]` | The pattern(s) to match against the previous URL                    |
+| `to`        | required | `string \| string[]` | The pattern(s) to match against the next URL                        |
+| `fragments` | required | `string[]`           | Selectors of containers to be replaced if the visit matches         |
+| `name`      | optional | `string`             | A name for this rule to allow scoped styling, ideally in kebab-case |
+
+### (List)
+
+- `from`, required, `string | string[]` — The pattern(s) to match against the previous URL
+- `to`, required, `string | string[]` — The pattern(s) to match against the next URL
+- `fragments`, required, `string[]` — Selectors of containers to be replaced if the visit matches
+- `name`, optional, `string` — A name for this rule to allow scoped styling, ideally in kebab-case
+
+### (Headings)
 
 #### from
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ When a visit is determinded to be a fragment visit, the plugin will:
 - **wait** for CSS transitions on those fragment elements using [scoped animations](https://swup.js.org/options/#animation-scope)
 - **preserve** the current scroll position upon navigation
 - add a `to-fragment-[name]` class to the elements if the current `rule` has a `name`  key
-- ignore the visit completely if a fragment already matches the current visit's URL
+- **ignore** the visit completely if a fragment already matches the current visit's URL
 
 ## Example
 
-### Content filter: only update results
+### Content filter: only update list of results
 
 A website has a page `/users/` that displays a list of users. Above the user list, there
 is a filter UI to choose which users to display. Selecting a filter will trigger a visit

--- a/README.md
+++ b/README.md
@@ -38,32 +38,32 @@ where the Fragment Plugin comes in.
 ```html
 <!DOCTYPE html>
 <html>
-  <title>My Website</title>
+  <title>Our Users — My Website</title>
 </html>
 <body>
-  <h1>My Website</h1>
+  <div>My Website</div>
   <nav><!-- ... --></nav>
   <div id="swup" class="transition-main">
-    <h2>Our users</h2>
+    <h1>Our Users</h1>
     <main id="users" class="transition-users">
       <!-- A list of filters for the users -->
       <ul>
-        <a href="/users/filter1">Filter 1</a>
-        <a href="/users/filter2">Filter 2</a>
-        <a href="/users/filter3">Filter 2</a>
+        <a href="/users/filter/1/">Filter 1</a> <!-- Clicking here should update the list below -->
+        <a href="/users/filter/2/">Filter 2</a>
+        <a href="/users/filter/3/">Filter 2</a>
       </ul>
       <!-- The list of users, different for each filter -->
       <ul>
-        <li><a href="/user/user1/">User 1</a></li>
-        <li><a href="/user/user2/">User 2</a></li>
-        <li><a href="/user/user3/">User 3</a></li>
+        <li><a href="/user/1/">User 1</a></li>
+        <li><a href="/user/2/">User 2</a></li>
+        <li><a href="/user/3/">User 3</a></li>
       </ul>
     </main>
   </div>
 </body>
 ```
 
-Now you can tell Fragment Plugin to **only** replace `#users` when clicking one of the filters:
+You can tell the Fragment Plugin to **only** update the `#users` list when clicking one of the filters:
 
 ```js
 const swup = new Swup({

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 A [swup](https://swup.js.org) plugin for selectively updating dynamic fragments.
 
-- Replace dynamic fragments instead of swup's default containers, based on custom rules
-- Communicate context and improve orientation by animating only the parts of the page that have actually changed
+- Replace dynamic fragments instead of the main content container, based on custom rules
+- Improve orientation by animating only the parts of the page that have actually changed
+- Give your site the polish and snappiness of a single-page app
 
 ## Use cases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
-        "@swup/plugin": "npm:@daun/swup-plugin@^3.0.0-rc.3",
-        "path-to-regexp": "^6.2.1",
-        "scrl": "^2.0.0"
+        "@swup/plugin": "npm:@daun/swup-plugin@^3.0.0-rc.3"
       },
       "devDependencies": {
         "swup": "npm:@daun/swup@^4.0.0-rc.17"
@@ -5219,11 +5217,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/scrl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/scrl/-/scrl-2.0.0.tgz",
-      "integrity": "sha512-BbbVXxrOn58Ge4wjOORIRVZamssQu08ISLL/AC2z9aATIsKqZLESwZVW5YR0Yz0C7qqDRHb4yNXJlQ8yW0SGHw=="
     },
     "node_modules/semver": {
       "version": "6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@swup/fragment-plugin",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@swup/plugin": "npm:@daun/swup-plugin@^3.0.0-rc.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@swup/fragment-plugin",
   "amdName": "SwupFragmentPlugin",
   "version": "0.0.11",
-  "description": "Allow for swup to replace fragments instead of the default containers between selected page visits",
+  "description": "A swup plugin for replacing dynamic fragments",
   "type": "module",
   "source": "src/index.ts",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,7 @@
     "url": "https://github.com/swup/fragment-plugin.git"
   },
   "dependencies": {
-    "@swup/plugin": "npm:@daun/swup-plugin@^3.0.0-rc.3",
-    "path-to-regexp": "^6.2.1",
-    "scrl": "^2.0.0"
+    "@swup/plugin": "npm:@daun/swup-plugin@^3.0.0-rc.3"
   },
   "devDependencies": {
     "swup": "npm:@daun/swup@^4.0.0-rc.17"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@swup/fragment-plugin",
   "amdName": "SwupFragmentPlugin",
   "version": "0.0.9",
-  "description": "Allow for swup to replace fragments instead of the default containers between selected page visits",
+  "description": "A swup plugin for selectively updating dynamic fragments",
   "type": "module",
   "source": "src/index.ts",
   "main": "./dist/index.cjs",

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -63,6 +63,11 @@ export default class SwupFragmentPlugin extends PluginBase {
 
 	logger: Logger;
 
+	defaults: PluginOptions = {
+		rules: [],
+		debug: false
+	};
+
 	/**
 	 * Plugin Constructor
 	 * The options are NOT optional and need to contain at least a `rules` property
@@ -70,15 +75,8 @@ export default class SwupFragmentPlugin extends PluginBase {
 	constructor(options: PluginOptions) {
 		super();
 
-		const defaults: PluginOptions = {
-			rules: [],
-			debug: false
-		};
+		this.options = { ...this.defaults, ...options };
 
-		this.options = {
-			...defaults,
-			...options
-		};
 		this.logger = new Logger({
 			prefix: '[@swup/fragment-plugin]',
 			muted: this.options.debug !== true


### PR DESCRIPTION
- Some ideas for the readme
- I've added variants for the `rules` section: table, list, and headings, not sure here but I prefer the more compact list version because it corresponds directly to the example code above: 1 line per property
- Best to view this from the branch's [readme view](https://github.com/swup/fragment-plugin/tree/docs#readme)
- Includes two drive-by improvements
  - extraction of default options into `this.defaults`
  - removal of unused dependencies
