### PR TITLE
New swup API function: `swup.getFragmentVisit(route)`

### DIFF
--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -122,7 +122,7 @@ export default class SwupFragmentPlugin extends PluginBase {
 
 		if (__DEV__) {
 			this.logger?.warnIf(
-				swup.options.cache,
+				!swup.options.cache,
 				`fragment caching will only work with swup's cache being active`
 			);
 		}

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -2,11 +2,7 @@ import PluginBase from '@swup/plugin';
 import Rule from './inc/Rule.js';
 import type { Path } from 'swup';
 import Logger from './inc/Logger.js';
-import {
-	handlePageView,
-	cleanupFragmentElements,
-	getFragmentVisit
-} from './inc/functions.js';
+import { handlePageView, cleanupFragmentElements, getFragmentVisit } from './inc/functions.js';
 
 import * as handlers from './inc/handlers.js';
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -135,7 +135,6 @@ export default class SwupFragmentPlugin extends PluginBase {
 	 */
 	unmount() {
 		super.unmount();
-		this.logger = undefined;
 		this.swup.getFragmentVisit = undefined;
 		cleanupFragmentElements();
 	}

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -114,7 +114,7 @@ function prepareFragmentElements({ rules, swup, logger }: FragmentPlugin): void 
 /**
  * Get all containers that should be replaced for a given visit's route
  */
-export const getFragmentsForVisit = (route: Route, selectors: string[], logger?: Logger) => {
+export const getContainersForVisit = (route: Route, selectors: string[], logger?: Logger) => {
 	return selectors.filter((selector) => {
 		const el = document.querySelector(selector) as FragmentElement;
 
@@ -345,9 +345,9 @@ export function getFragmentVisit(
 	// Bail early if no rule matched
 	if (!rule) return;
 
-	// Validate the containers from the matched rule
-	const containers = getFragmentsForVisit(route, rule.containers, logger);
-	// Bail early if there are no valid containers for the rule
+	// Get containers that should be replaced for this visit
+	const containers = getContainersForVisit(route, rule.containers, logger);
+	// Bail early if there are no containers to be replaced for this visit
 	if (!containers.length) return;
 
 	const visit: FragmentVisit = {

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -335,7 +335,11 @@ export function dedupe<T>(arr: Array<T>): Array<T> {
 /**
  * Get the fragment visit object for a given route
  */
-export function getFragmentVisit(this: SwupFragmentPlugin, route: Route, logger?: Logger): FragmentVisit | undefined {
+export function getFragmentVisit(
+	this: SwupFragmentPlugin,
+	route: Route,
+	logger?: Logger
+): FragmentVisit | undefined {
 	const rule = getFirstMatchingRule(route, this.rules);
 
 	// Bail early if no rule matched

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -1,6 +1,6 @@
 import { Location } from 'swup';
 import type { Visit } from 'swup';
-import { default as FragmentPlugin } from '../SwupFragmentPlugin.js';
+import SwupFragmentPlugin, { default as FragmentPlugin } from '../SwupFragmentPlugin.js';
 import type { Rule, Route, FragmentVisit, FragmentElement } from '../SwupFragmentPlugin.js';
 import Logger, { highlight } from './Logger.js';
 
@@ -330,4 +330,26 @@ export function shouldSkipAnimation({ swup }: FragmentPlugin): boolean {
  */
 export function dedupe<T>(arr: Array<T>): Array<T> {
 	return [...new Set<T>(arr)];
+}
+
+/**
+ * Get the fragment visit object for a given route
+ */
+export function getFragmentVisit(this: SwupFragmentPlugin, route: Route, logger?: Logger): FragmentVisit | undefined {
+	const rule = getFirstMatchingRule(route, this.rules);
+
+	// Bail early if no rule matched
+	if (!rule) return;
+
+	// Validate the containers from the matched rule
+	const containers = getFragmentsForVisit(route, rule.containers, logger);
+	// Bail early if there are no valid containers for the rule
+	if (!containers.length) return;
+
+	const visit: FragmentVisit = {
+		rule,
+		containers
+	};
+
+	return visit;
 }

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -9,7 +9,8 @@ import {
 	removeRuleNameFromFragments,
 	getFirstMatchingRule,
 	cacheForeignFragmentElements,
-	shouldSkipAnimation
+	shouldSkipAnimation,
+	getFragmentVisit
 } from './functions.js';
 
 import { __DEV__ } from './env.js';
@@ -34,7 +35,7 @@ export const onVisitStart: Handler<'visit:start'> = async function (this: Fragme
 	const route = getRoute(visit);
 	if (!route) return;
 
-	const fragmentVisit = this.getFragmentVisit(route, this.logger);
+	const fragmentVisit = getFragmentVisit.call(this, route, this.logger);
 
 	/**
 	 * Bail early if the current route doesn't match


### PR DESCRIPTION
**Description**

Injects an API function into swup to allow to retrieve the fragment visit object for any route. Example:

```typescript
import Swup, { Location } from "swup";

const swup = new Swup({
  plugins: [
    new FragmentPlugin({ rules }),
  ],
});
/**
 * Get the fragment visit when hovering internal links
 */
const onHoverLink = ({ target: el }) => {
  const isLink = el instanceof HTMLAnchorElement;
  if (!isLink) return;

  // ignore external links
  if (el.origin !== location.origin) return;

  // ignore anchor links
  if (el.getAttribute("href")?.startsWith("#")) return;

  // ignore links to same page
  if (
    Location.fromElement(el).url === Location.fromUrl(window.location.href).url
  )
    return;

  const fragmentVisit = swup.getFragmentVisit?.({
    from: Location.fromUrl(window.location.href).url,
    to: Location.fromElement(el).url,
  });
  // Log the result (either a FragmentVisit or undefined)
  console.log(fragmentVisit);
};
// Delegate mouseenter
swup.delegateEvent(swup.options.linkSelector, "mouseenter", onHoverLink, {
  capture: true,
});
```

**Drive-by**
- don't set the logger to `undefined` on `unmount`
- warn if swup's cache is `false`, not `true` 🤦‍♂️😁

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- ~The documentation was updated as required~ Maybe later :)