### PR TITLE
Simplify `visit.fragmentVisit`

### DIFF
--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -55,7 +55,7 @@ type InitOptions = RequireKeys<Options, 'rules'>;
  * The state of the current visit
  */
 export type FragmentVisit = {
-	name?: string,
+	name?: string;
 	containers: string[];
 };
 
@@ -96,7 +96,8 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name }) => new ParsedRule(from, to, containers, name, this.logger)
+			({ from, to, containers, name }) =>
+				new ParsedRule(from, to, containers, name, this.logger)
 		);
 	}
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -55,7 +55,7 @@ type InitOptions = RequireKeys<Options, 'rules'>;
  * The state of the current visit
  */
 export type FragmentVisit = {
-	rule: ParsedRule;
+	name?: string,
 	containers: string[];
 };
 

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -199,21 +199,21 @@ export const getRoute = (visit: Visit): Route | undefined => {
 export const addRuleNameClasses = (visit: Visit): void => {
 	if (!visit.fragmentVisit) return;
 
-	const { rule, containers } = visit.fragmentVisit;
-	if (!rule.name) return;
+	const { name, containers } = visit.fragmentVisit;
+	if (!name) return;
 
 	containers.forEach((selector) => {
-		document.querySelector(selector)?.classList.add(`to-${rule.name}`);
+		document.querySelector(selector)?.classList.add(`to-${name}`);
 	});
 };
 
 /**
  * Remove the rule name from fragment elements
  */
-export const removeRuleNameFromFragments = ({ rule, containers }: FragmentVisit): void => {
-	if (!rule.name) return;
+export const removeRuleNameFromFragments = ({ name, containers }: FragmentVisit): void => {
+	if (!name) return;
 	containers.forEach((selector) => {
-		document.querySelector(selector)?.classList.remove(`to-${rule.name}`);
+		document.querySelector(selector)?.classList.remove(`to-${name}`);
 	});
 };
 
@@ -351,7 +351,7 @@ export function getFragmentVisit(
 	if (!containers.length) return;
 
 	const visit: FragmentVisit = {
-		rule,
+		name: rule.name,
 		containers
 	};
 

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -136,5 +136,4 @@ export const onContentReplace: Handler<'content:replace'> = function (this: Frag
  */
 export const onVisitEnd: Handler<'visit:end'> = function (this: FragmentPlugin, visit) {
 	if (visit.fragmentVisit) removeRuleNameFromFragments(visit.fragmentVisit);
-	visit.fragmentVisit = undefined;
 };


### PR DESCRIPTION
**Description**

Right now `visit.fragmentVisit` contains quite some unnecessary information: 

```typescript
export type FragmentVisit = {
    rule: {
        from: Path,
        to: Path,
        containers: string[],
        matchesFrom: (path: Path) => boolean,
        matchesTo: (path: Path) => boolean,
        name?: string
    },
    containers: string[]
}
```

I'd propose to simplify it to this:

```js
/**
 * The state of the current visit
 */
export type FragmentVisit = {
	name?: string,
	containers: string[];
};
```

**Usage Example**

Don't reset the scroll position for a fragment visit with name "my-fragment-visit":

```ts
swup.hooks.on('visit:start', async (visit) => {
  if (visit.fragmentVisit?.name === 'my-fragment-visit') {
    visit.scroll.reset = true;
  }
})
```

`visit.fragmentVisit.containers` would be equal to `visit.containers`, but I would keep then around for debugging purposes. 

Any other ideas? 

Since `visit.fragmentVisit` is not documented yet, I would consider this a non-breaking change.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)

