### PR TITLE
feat: new option `rule.scroll`

### DIFF
--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -42,6 +42,7 @@ export type Rule = {
 	to: Path;
 	containers: string[];
 	name?: string;
+	scroll?: boolean | string;
 };
 
 export type Options = {
@@ -57,6 +58,7 @@ type InitOptions = RequireKeys<Options, 'rules'>;
 export type FragmentVisit = {
 	name?: string;
 	containers: string[];
+	scroll: boolean | string;
 };
 
 /**
@@ -96,8 +98,8 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name }) =>
-				new ParsedRule(from, to, containers, name, this.logger)
+			({ from, to, containers, name, scroll }) =>
+				new ParsedRule(from, to, containers, name, scroll, this.logger)
 		);
 	}
 

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -7,7 +7,7 @@ import { __DEV__ } from './env.js';
 /**
  * Represents a Rule
  */
-export default class Rule {
+export default class ParsedRule {
 	readonly matchesFrom;
 	readonly matchesTo;
 
@@ -15,12 +15,21 @@ export default class Rule {
 	to: Path;
 	containers: string[];
 	name?: string;
+	scroll: boolean | string = false;
 
-	constructor(from: Path, to: Path, rawContainers: string[], name?: string, logger?: Logger) {
+	constructor(
+		from: Path,
+		to: Path,
+		rawContainers: string[],
+		name?: string,
+		scroll?: boolean | string,
+		logger?: Logger
+	) {
 		this.from = from || '';
 		this.to = to || '';
 
 		if (name) this.name = classify(name);
+		if (typeof scroll !== 'undefined') this.scroll = scroll;
 
 		this.containers = this.parseContainers(rawContainers, logger);
 

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -1,5 +1,5 @@
 import { Location } from 'swup';
-import type { Visit } from 'swup';
+import type { Visit, VisitScroll } from 'swup';
 import SwupFragmentPlugin, { default as FragmentPlugin } from '../SwupFragmentPlugin.js';
 import type { ParsedRule, Route, FragmentVisit, FragmentElement } from '../SwupFragmentPlugin.js';
 import Logger, { highlight } from './Logger.js';
@@ -350,10 +350,30 @@ export function getFragmentVisit(
 	// Bail early if there are no containers to be replaced for this visit
 	if (!containers.length) return;
 
+	// Pick properties from the current rule that should be projected into the fragmentVisit object
+	const { name, scroll } = rule;
+
 	const visit: FragmentVisit = {
-		name: rule.name,
-		containers
+		containers,
+		name,
+		scroll
 	};
 
 	return visit;
+}
+
+/**
+ * Adjusts visit.scroll based on given fragment visit
+ */
+export function adjustVisitScroll(
+	fragmentVisit: FragmentVisit,
+	scroll: VisitScroll
+): VisitScroll {
+	if (typeof fragmentVisit.scroll === 'boolean') {
+		return { ...scroll, reset: fragmentVisit.scroll };
+	}
+	if (typeof fragmentVisit.scroll === 'string' && !scroll.target) {
+		return { ...scroll, target: fragmentVisit.scroll };
+	}
+	return scroll;
 }

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -365,10 +365,7 @@ export function getFragmentVisit(
 /**
  * Adjusts visit.scroll based on given fragment visit
  */
-export function adjustVisitScroll(
-	fragmentVisit: FragmentVisit,
-	scroll: VisitScroll
-): VisitScroll {
+export function adjustVisitScroll(fragmentVisit: FragmentVisit, scroll: VisitScroll): VisitScroll {
 	if (typeof fragmentVisit.scroll === 'boolean') {
 		return { ...scroll, reset: fragmentVisit.scroll };
 	}

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -10,7 +10,8 @@ import {
 	getFirstMatchingRule,
 	cacheForeignFragmentElements,
 	shouldSkipAnimation,
-	getFragmentVisit
+	getFragmentVisit,
+	adjustVisitScroll
 } from './functions.js';
 
 import { __DEV__ } from './env.js';
@@ -45,11 +46,11 @@ export const onVisitStart: Handler<'visit:start'> = async function (this: Fragme
 
 	visit.fragmentVisit = fragmentVisit;
 
-	if (__DEV__)
+	if (__DEV__) {
 		this.logger?.log(`fragment visit: ${highlight(visit.fragmentVisit.containers.join(', '))}`);
+	}
 
-	// Disable scrolling for this transition
-	visit.scroll.reset = false;
+	visit.scroll = adjustVisitScroll(fragmentVisit, visit.scroll);
 
 	// Add the transition classes directly to the containers for this visit
 	visit.animation.scope = visit.fragmentVisit.containers;


### PR DESCRIPTION
Closes #34 

**Description**

Adds a new rule option `scroll`, to overwrite the default behavior of disabling `scroll.reset` for fragment visits:

```typescript
{
  scroll?: boolean | string;
}
```

**Example1**

Scroll to the top for a selected fragment visit:

```js
const rules: FragmentRule[] = [
  {
    from: "/items/:filter?",
    to: "/items/:filter?",
    containers: ["#list"],
    scroll: true
  }
];
```

**Example 2**

Scroll to the element `#list` for a selected fragment visit:

```js
const rules: FragmentRule[] = [
  {
    from: "/items/:filter?",
    to: "/items/:filter?",
    containers: ["#list"],
    scroll: '#list'
  }
];
```


**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] The documentation was updated as required

