### PR TITLE
Feature: Support fragment visits to the current URL

### DIFF
--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -115,6 +115,8 @@ function prepareFragmentElements({ rules, swup, logger }: FragmentPlugin): void 
  * Get all containers that should be replaced for a given visit's route
  */
 export const getContainersForVisit = (route: Route, selectors: string[], logger?: Logger) => {
+	const isReload = isEqualUrl(route.from, route.to);
+
 	return selectors.filter((selector) => {
 		const el = document.querySelector(selector) as FragmentElement;
 
@@ -123,7 +125,7 @@ export const getContainersForVisit = (route: Route, selectors: string[], logger?
 			return false;
 		}
 
-		if (elementMatchesFragmentUrl(el, route.to)) {
+		if (!isReload && elementMatchesFragmentUrl(el, route.to)) {
 			if (__DEV__)
 				logger?.log(
 					`ignored fragment ${highlight(selector)} as it already matches the current URL`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "include": ["src"],
   "compilerOptions": {
-    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "moduleResolution": "Node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
-    "rootDirs": ["./src"],                               /* Allow multiple folders to be treated as one when resolving modules. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "moduleResolution": "Node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "rootDirs": ["./src"] /* Allow multiple folders to be treated as one when resolving modules. */,
+    "resolveJsonModule": true /* Enable importing .json files. */,
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */
   }
 }


### PR DESCRIPTION
Solves https://github.com/orgs/swup/discussions/761#discussioncomment-6683760

**Description**

Doesn't check for the fragment-url anymore, if `route.from` and `route.to` can be considered equal. Unlocks fragment visits if running `swup.navigate(swup.getCurrentUrl())`, for example

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)

