### PR TITLE
Feature/a11y focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ export type Options = {
     containers: string[];
     name?: string;
     scroll?: boolean | string;
+    focus?: boolean | string;
   }>;
   debug?: boolean;
 };
@@ -208,6 +209,10 @@ Using this option, you can re-enable it for selected visits:
 
 - `true` will scroll to the top
 - `'#my-element'` will scroll to the first element matching the selector
+
+#### rule.focus
+
+Optional, Type: `boolean | string` – If you have [Accessibility Plugin](https://github.com/swup/a11y-plugin/) installed, you can adjust wich element to focus for the visit [as described here](https://github.com/swup/a11y-plugin/#visita11yfocus).
 
 ### debug
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Using this option, you can re-enable it for selected visits:
 
 #### rule.focus
 
-Optional, Type: `boolean | string` – If you have [Accessibility Plugin](https://github.com/swup/a11y-plugin/) installed, you can adjust wich element to focus for the visit [as described here](https://github.com/swup/a11y-plugin/#visita11yfocus).
+Optional, Type: `boolean | string` – If you have [Accessibility Plugin](https://github.com/swup/a11y-plugin/) installed, you can adjust which element to focus for the visit [as described here](https://github.com/swup/a11y-plugin/#visita11yfocus).
 
 ### debug
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -43,6 +43,7 @@ export type Rule = {
 	containers: string[];
 	name?: string;
 	scroll?: boolean | string;
+	focus?: boolean | string;
 };
 
 export type Options = {
@@ -59,6 +60,7 @@ export type FragmentVisit = {
 	name?: string;
 	containers: string[];
 	scroll: boolean | string;
+	focus?: boolean | string;
 };
 
 /**
@@ -98,8 +100,8 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name, scroll }) =>
-				new ParsedRule(from, to, containers, name, scroll, this.logger)
+			({ from, to, containers, name, scroll, focus }) =>
+				new ParsedRule(from, to, containers, name, scroll, focus, this.logger)
 		);
 	}
 

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -17,6 +17,7 @@ export default class ParsedRule {
 	containers: string[];
 	name?: string;
 	scroll: boolean | string = false;
+	focus?: boolean | string;
 
 	constructor(
 		from: Path,
@@ -24,6 +25,7 @@ export default class ParsedRule {
 		rawContainers: string[],
 		name?: string,
 		scroll?: boolean | string,
+		focus?: boolean | string,
 		logger?: Logger
 	) {
 		this.from = from || '';
@@ -31,12 +33,14 @@ export default class ParsedRule {
 
 		if (name) this.name = classify(name);
 		if (typeof scroll !== 'undefined') this.scroll = scroll;
+		if (typeof focus !== 'undefined') this.focus = focus;
 
 		this.containers = this.parseContainers(rawContainers, logger);
 
 		if (__DEV__) {
 			logger?.errorIf(!to, `Every fragment rule must contain a 'to' path`, this);
 			logger?.errorIf(!from, `Every fragment rule must contain a 'from' path`, this);
+
 		}
 
 		this.matchesFrom = matchPath(from);

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -40,7 +40,6 @@ export default class ParsedRule {
 		if (__DEV__) {
 			logger?.errorIf(!to, `Every fragment rule must contain a 'to' path`, this);
 			logger?.errorIf(!from, `Every fragment rule must contain a 'from' path`, this);
-
 		}
 
 		this.matchesFrom = matchPath(from);

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -353,12 +353,13 @@ export function getFragmentVisit(
 	if (!containers.length) return;
 
 	// Pick properties from the current rule that should be projected into the fragmentVisit object
-	const { name, scroll } = rule;
+	const { name, scroll, focus } = rule;
 
 	const visit: FragmentVisit = {
 		containers,
 		name,
-		scroll
+		scroll,
+		focus
 	};
 
 	return visit;

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -57,7 +57,10 @@ export const onVisitStart: Handler<'visit:start'> = async function (this: Fragme
 	const a11y = visit.a11y as { focus?: boolean | string };
 	if (typeof fragmentVisit.focus !== 'undefined') {
 		if (__DEV__) {
-			this.logger?.errorIf(!a11y, 'Can\'t set visit.a11y.focus. Is @swup/a11y-plugin installed?');
+			this.logger?.errorIf(
+				!a11y,
+				"Can't set visit.a11y.focus. Is @swup/a11y-plugin installed?"
+			);
 		}
 		if (a11y) a11y.focus = fragmentVisit.focus;
 	}

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -52,6 +52,16 @@ export const onVisitStart: Handler<'visit:start'> = async function (this: Fragme
 
 	visit.scroll = adjustVisitScroll(fragmentVisit, visit.scroll);
 
+	// Fragment Plugin can't know if Accesssibilty Plugin is installed
+	// @ts-expect-error
+	const a11y = visit.a11y as { focus?: boolean | string };
+	if (typeof fragmentVisit.focus !== 'undefined') {
+		if (__DEV__) {
+			this.logger?.errorIf(!a11y, 'Can\'t set visit.a11y.focus. Is @swup/a11y-plugin installed?');
+		}
+		if (a11y) a11y.focus = fragmentVisit.focus;
+	}
+
 	// Add the transition classes directly to the containers for this visit
 	visit.animation.scope = visit.fragmentVisit.containers;
 


### PR DESCRIPTION
Closes #42 

**Description**

Allows to customize [the focus for a visit](https://github.com/swup/a11y-plugin/#visita11yfocus) per fragment rule, if Accessibility Plugin is installed. 

This will not move the focus at all:

```js
{
  focus: false
}
```

Exception: If the currently focused element will be replaced during the visit, the focus will automatically be moved to the `body` by the browser.

This will move the focus to the first element matching `#my-element`:

```js
{
  focus: '#my-element'
}
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

