### PR TITLE
feat : `rule.if`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ The rule's `from`/`to` paths are converted to a regular expression by [path-to-r
       to: '/users/:filter?', // required
       containers: ['#users'], // required
       name: 'list', // optional, default: empty string
+      if: (visit) => new Date().getHours() > 20 // optional, default: () => true
       scroll: true // optional, default: false
+      focus: '#my-fragment' // optional, default inherited in a11y plugin
     }
   ];
 }
@@ -201,6 +203,10 @@ Required, Type: `string[]` – Selectors of containers to be replaced if the vis
 #### rule.name
 
 Optional, Type: `string` – A name for this rule to allow scoped styling, ideally in kebab-case
+
+#### rule.if
+
+Optional, Type: `(visit: Visit) => boolean` – Returning `false` from this callback will ignore the rule for the current visit.
 
 #### rule.scroll
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ The rule's `from`/`to` paths are converted to a regular expression by [path-to-r
       from: '/users/:filter?', // required
       to: '/users/:filter?', // required
       containers: ['#users'], // required
+      if: (visit) => visit.to.url !== '/users/my-exception/', // optional, default: () => true
       name: 'list', // optional, default: empty string
-      if: (visit) => new Date().getHours() > 20 // optional, default: () => true
       scroll: true // optional, default: false
       focus: '#my-fragment' // optional, default inherited in a11y plugin
     }
@@ -200,13 +200,13 @@ Required, Type: `string[]` – Selectors of containers to be replaced if the vis
 > **Note** **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
 > `.my-element` or `#wrap #child` both will throw an error.
 
-#### rule.name
-
-Optional, Type: `string` – A name for this rule to allow scoped styling, ideally in kebab-case
-
 #### rule.if
 
 Optional, Type: `(visit: Visit) => boolean` – Returning `false` from this callback will ignore the rule for the current visit.
+
+#### rule.name
+
+Optional, Type: `string` – A name for this rule to allow scoped styling, ideally in kebab-case
 
 #### rule.scroll
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ export type Options = {
     from: string | string[];
     to: string | string[];
     containers: string[];
+    if: (visit) => boolean;
     name?: string;
     scroll?: boolean | string;
     focus?: boolean | string;

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -46,7 +46,7 @@ export type Rule = {
 	name?: string;
 	scroll?: boolean | string;
 	focus?: boolean | string;
-	if?: RuleConditionCallback
+	if?: RuleConditionCallback;
 };
 
 export type Options = {
@@ -103,8 +103,18 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name, scroll, focus, if: condition }) =>
-				new ParsedRule(from, to, containers, name, scroll, focus, condition, this.logger)
+			({ from, to, containers, name, scroll, focus, if: condition }) => {
+				return new ParsedRule(
+					from,
+					to,
+					containers,
+					name,
+					condition,
+					scroll,
+					focus,
+					this.logger
+				);
+			}
 		);
 	}
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -103,13 +103,13 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name, scroll, focus, if: condition }) => {
+			({ from, to, containers, if: condition, name, scroll, focus }) => {
 				return new ParsedRule(
 					from,
 					to,
 					containers,
-					name,
 					condition,
+					name,
 					scroll,
 					focus,
 					this.logger

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -1,6 +1,6 @@
 import PluginBase from '@swup/plugin';
 import ParsedRule from './inc/ParsedRule.js';
-import type { Path } from 'swup';
+import type { Path, Visit } from 'swup';
 import Logger from './inc/Logger.js';
 import { handlePageView, cleanupFragmentElements, getFragmentVisit } from './inc/functions.js';
 
@@ -37,6 +37,8 @@ export type Route = {
 	to: string;
 };
 
+export type RuleConditionCallback = (visit: Visit) => boolean;
+
 export type Rule = {
 	from: Path;
 	to: Path;
@@ -44,6 +46,7 @@ export type Rule = {
 	name?: string;
 	scroll?: boolean | string;
 	focus?: boolean | string;
+	if?: RuleConditionCallback
 };
 
 export type Options = {
@@ -100,8 +103,8 @@ export default class SwupFragmentPlugin extends PluginBase {
 		}
 
 		this.rules = this.options.rules.map(
-			({ from, to, containers, name, scroll, focus }) =>
-				new ParsedRule(from, to, containers, name, scroll, focus, this.logger)
+			({ from, to, containers, name, scroll, focus, if: condition }) =>
+				new ParsedRule(from, to, containers, name, scroll, focus, condition, this.logger)
 		);
 	}
 

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -16,18 +16,18 @@ export default class ParsedRule {
 	to: Path;
 	containers: string[];
 	name?: string;
+	condition: RuleConditionCallback = () => true;
 	scroll: boolean | string = false;
 	focus?: boolean | string;
-	condition: RuleConditionCallback = () => true;
 
 	constructor(
 		from: Path,
 		to: Path,
 		rawContainers: string[],
 		name?: string,
+		condition?: RuleConditionCallback,
 		scroll?: boolean | string,
 		focus?: boolean | string,
-		condition?: RuleConditionCallback,
 		logger?: Logger
 	) {
 		this.from = from || '';

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -24,8 +24,8 @@ export default class ParsedRule {
 		from: Path,
 		to: Path,
 		rawContainers: string[],
-		name?: string,
 		condition?: RuleConditionCallback,
+		name?: string,
 		scroll?: boolean | string,
 		focus?: boolean | string,
 		logger?: Logger

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -1,6 +1,5 @@
 import { matchPath, classify, Location } from 'swup';
-import type { Path } from 'swup';
-import type { Route } from './types.js';
+import type { Route, RuleConditionCallback, Path, Visit } from './types.js';
 import { dedupe } from './functions.js';
 import Logger, { highlight } from './Logger.js';
 import { __DEV__ } from './env.js';

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -222,8 +222,8 @@ export const removeRuleNameFromFragments = ({ name, containers }: FragmentVisit)
 /**
  * Get the first matching rule for a given route
  */
-export const getFirstMatchingRule = (route: Route, rules: ParsedRule[]): ParsedRule | undefined => {
-	return rules.find((rule) => rule.matches(route));
+export const getFirstMatchingRule = (route: Route, rules: ParsedRule[], visit: Visit): ParsedRule | undefined => {
+	return rules.find((rule) => rule.matches(route, visit));
 };
 
 /**
@@ -342,7 +342,7 @@ export function getFragmentVisit(
 	route: Route,
 	logger?: Logger
 ): FragmentVisit | undefined {
-	const rule = getFirstMatchingRule(route, this.rules);
+	const rule = getFirstMatchingRule(route, this.rules, this.swup.visit);
 
 	// Bail early if no rule matched
 	if (!rule) return;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -222,7 +222,11 @@ export const removeRuleNameFromFragments = ({ name, containers }: FragmentVisit)
 /**
  * Get the first matching rule for a given route
  */
-export const getFirstMatchingRule = (route: Route, rules: ParsedRule[], visit: Visit): ParsedRule | undefined => {
+export const getFirstMatchingRule = (
+	route: Route,
+	rules: ParsedRule[],
+	visit: Visit
+): ParsedRule | undefined => {
 	return rules.find((rule) => rule.matches(route, visit));
 };
 

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -1,7 +1,6 @@
 import { Location } from 'swup';
-import type { Visit, VisitScroll } from 'swup';
 import type { default as FragmentPlugin } from '../SwupFragmentPlugin.js';
-import type { Route, FragmentVisit, FragmentElement } from './types.js';
+import type { Route, FragmentVisit, FragmentElement, Visit, VisitScroll } from './types.js';
 import type ParsedRule from './ParsedRule.js';
 import Logger, { highlight } from './Logger.js';
 

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -24,7 +24,7 @@ export const onLinkToSelf: Handler<'link:self'> = function (this: FragmentPlugin
 	const route = getRoute(visit);
 	if (!route) return;
 
-	const rule = getFirstMatchingRule(route, this.rules);
+	const rule = getFirstMatchingRule(route, this.rules, visit);
 
 	if (rule) visit.scroll.reset = false;
 };

--- a/src/inc/types.d.ts
+++ b/src/inc/types.d.ts
@@ -1,4 +1,4 @@
-import type { Path } from 'swup';
+export type { Path, Visit, VisitScroll } from 'swup';
 
 /** Represents a route from one to another URL */
 export type Route = {
@@ -15,6 +15,8 @@ export interface FragmentElement extends Element {
 	};
 }
 
+export type RuleConditionCallback = (visit: Visit) => boolean;
+
 /** A fragment rule */
 export type Rule = {
 	from: Path;
@@ -23,6 +25,7 @@ export type Rule = {
 	name?: string;
 	scroll?: boolean | string;
 	focus?: boolean | string;
+	if?: RuleConditionCallback
 };
 
 /** The plugin options */


### PR DESCRIPTION
**On Hold**

The issue was solvable by making sure that **all fragments in a rule must match an element in the `document`**. I'll keep this PR around and in sync with `master`, should we need it sometime.

**Description**

Adds a new property `if` to fragment rules, to only run rules if they match the callback:

```js
{
  rules: [
    {
      from: '/users/:filter?',
      to: '/users/:filter?', 
      containers: ['#users'],
      if: () => new Date().getHours() > 20 // only do this after 8pm 👾
    }
  ];
}
```

Or:

```js
{
  rules: [
    {
      from: '/users/:filter?',
      to: '/users/:filter?', 
      containers: ['#users'],
      if: (visit) => visit.to.url !== '/users/my-exception/' // Don't do this for an exact match with '/users/my-exception'/
    }
  ];
}
```

The real use case I'm using it for:

```js
const rules: Rule[] = [
	/** Home, Projects & Filters <---> Single Project */
	{
		from: ['/', '/projects', '/projects/filter/:filter'],
		to: '/projects/:slug',
		containers: ['#project'],
	},
	{
		from: '/projects/:slug',
		to: ['/'],
		containers: ['#project'],
	},
	{
		from: '/projects/:slug',
		to: ['/projects', '/projects/filter/:filter'],
		containers: ['#project', '#projectslist'],
		name: 'from-project-to-projects',
		if: () => !Boolean(document.querySelector('.page.home'))
	},
	/** Projects & Filters <---> Projects & Filters */
	{
		from: ['/projects', '/projects/filter/:filter'],
		to: ['/projects', '/projects/filter/:filter'],
		containers: ['#projectslist', '#page-header'],
		name: 'projectslist',
		focus: false,
	},
];
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

