### PR TITLE
feat : check for missing fragment elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@ Required, Type: `string | string[]` – The path(s) to match against the next UR
 
 Required, Type: `string[]` – Selectors of containers to be replaced if the visit matches.
 
-> **Note** **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
-> `.my-element` or `#wrap #child` both will throw an error.
+**Notes**
+
+- **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
+`.my-element` or `#wrap #child` both will throw an error.
+- if **any** of the selectors in `containers` doesn't return a match in the current document, the rule will be skipped.
 
 #### rule.name
 

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -91,13 +91,22 @@ export default class ParsedRule {
 		if (!matches) return false;
 
 		/** Don't match if any of the selectors doesn't match an element */
-		if (this.containers.find((selector) => {
-			const isMissing = document.querySelector(selector) === null;
-			if (__DEV__) {
-				this.logger?.logIf(isMissing, `skipping fragment rule since ${highlight(selector)} doesn't match anything`, route);
-			}
-			return isMissing;
-		})) return false;
+		if (
+			this.containers.find((selector) => {
+				const isMissing = document.querySelector(selector) === null;
+				if (__DEV__) {
+					this.logger?.logIf(
+						isMissing,
+						`skipping fragment rule since ${highlight(
+							selector
+						)} doesn't match anything`,
+						route
+					);
+				}
+				return isMissing;
+			})
+		)
+			return false;
 
 		return true;
 	}

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -97,9 +97,8 @@ export default class ParsedRule {
 				if (__DEV__) {
 					this.logger?.logIf(
 						isMissing,
-						`skipping fragment rule since ${highlight(
-							selector
-						)} doesn't match anything`,
+						`skipping fragment rule since ${highlight(selector)}
+						doesn't match anything`,
 						route
 					);
 				}

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -97,8 +97,8 @@ export default class ParsedRule {
 				if (__DEV__) {
 					this.logger?.logIf(
 						isMissing,
-						`skipping fragment rule since ${highlight(selector)}
-						doesn't match anything`,
+						`skipping fragment rule since ` +
+							`${highlight(selector)} doesn't match anything`,
 						route
 					);
 				}


### PR DESCRIPTION
**Description**

Introduces a check while matching fragment rules, that validates if any of the selectors in `rule.containers` doesn't return a match in the current document. If so, the rule will be skipped for the current visit.

Makes the PR #47 unnecessary for the use case I'm facing right now. I'd like to keep the `rule` API surface as small as possible until we stumble on a use case where we really need to expand it. We can keep the `rule.if` PR open and in sync, should we need it sometime.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required
