### PR TITLE
feat: validate location of fragment elements in DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.4] - 2023-10-15
+
+- Ignore fragment elements that are not children of swup's default `containers`
+
 ## [0.3.3] - 2023-10-05
 
 - Refactor exports
@@ -43,6 +47,7 @@
 
 - Initial Release
 
+[0.3.4]: https://github.com/swup/fragment-plugin/releases/tag/0.3.4
 [0.3.3]: https://github.com/swup/fragment-plugin/releases/tag/0.3.3
 [0.3.2]: https://github.com/swup/fragment-plugin/releases/tag/0.3.2
 [0.3.1]: https://github.com/swup/fragment-plugin/releases/tag/0.3.1

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Required, Type: `string[]` – Selectors of containers to be replaced if the vis
 - **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
 `.my-element` or `#wrap #child` both will throw an error.
 - if **any** of the selectors in `containers` doesn't return a match in the current document, the rule will be skipped.
+- Fragment containers **must be children** of swup's main `containers`. Otherwise, they will be ignored.
 
 #### rule.name
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Required, Type: `string[]` – Selectors of containers to be replaced if the vis
 - **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
 `.my-element` or `#wrap #child` both will throw an error.
 - if **any** of the selectors in `containers` doesn't return a match in the current document, the rule will be skipped.
-- Fragment containers **must be children** of swup's main `containers`. Otherwise, they will be ignored.
+- Fragment elements **must either match a swup container or be a descendant of one of them**
 
 #### rule.name
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swup/fragment-plugin",
   "amdName": "SwupFragmentPlugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A swup plugin for dynamically replacing containers based on rules",
   "type": "module",
   "source": "src/index.ts",

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -90,14 +90,14 @@ export default class SwupFragmentPlugin extends PluginBase {
 	/**
 	 * Get the fragment visit object for a given route
 	 */
-	getFragmentVisit(route: Route, visit?: Visit): FragmentVisit | undefined {
+	getFragmentVisit(route: Route): FragmentVisit | undefined {
 		const rule = getFirstMatchingRule(route, this.rules);
 
 		// Bail early if no rule matched
 		if (!rule) return;
 
 		// Get containers that should be replaced for this visit
-		const containers = getFragmentVisitContainers(route, rule.containers, visit, this.logger);
+		const containers = getFragmentVisitContainers(route, rule.containers, this.swup, this.logger);
 		// Bail early if there are no containers to be replaced for this visit
 		if (!containers.length) return;
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -84,6 +84,7 @@ export default class SwupFragmentPlugin extends PluginBase {
 	unmount() {
 		super.unmount();
 		this.swup.getFragmentVisit = undefined;
+		this.rules = [];
 		cleanupFragmentElements();
 	}
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -98,7 +98,12 @@ export default class SwupFragmentPlugin extends PluginBase {
 		if (!rule) return;
 
 		// Get containers that should be replaced for this visit
-		const containers = getFragmentVisitContainers(route, rule.containers, this.swup, this.logger);
+		const containers = getFragmentVisitContainers(
+			route,
+			rule.containers,
+			this.swup,
+			this.logger
+		);
 		// Bail early if there are no containers to be replaced for this visit
 		if (!containers.length) return;
 

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -45,11 +45,6 @@ export default class SwupFragmentPlugin extends PluginBase {
 		if (__DEV__) {
 			if (this.options.debug) this.logger = new Logger();
 		}
-
-		this.rules = this.options.rules.map(
-			({ from, to, containers, name, scroll, focus }) =>
-				new ParsedRule(from, to, containers, name, scroll, focus, this.logger)
-		);
 	}
 
 	/**
@@ -57,6 +52,11 @@ export default class SwupFragmentPlugin extends PluginBase {
 	 */
 	mount() {
 		const swup = this.swup;
+
+		this.rules = this.options.rules.map(
+			({ from, to, containers, name, scroll, focus }) =>
+				new ParsedRule(from, to, containers, name, scroll, focus, this.logger)
+		);
 
 		this.before('link:self', handlers.onLinkToSelf);
 		this.on('visit:start', handlers.onVisitStart);

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -55,7 +55,7 @@ export default class SwupFragmentPlugin extends PluginBase {
 
 		this.rules = this.options.rules.map(
 			({ from, to, containers, name, scroll, focus }) =>
-				new ParsedRule(from, to, containers, name, scroll, focus, this.logger)
+				new ParsedRule(this, from, to, containers, name, scroll, focus, this.logger)
 		);
 
 		this.before('link:self', handlers.onLinkToSelf);

--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -5,11 +5,12 @@ import {
 	handlePageView,
 	cleanupFragmentElements,
 	getFirstMatchingRule,
-	getContainersForVisit
+	getFragmentVisitContainers
 } from './inc/functions.js';
 import type { Options, Route, FragmentVisit } from './inc/defs.js';
 import * as handlers from './inc/handlers.js';
 import { __DEV__ } from './inc/env.js';
+import type { Visit } from 'swup';
 
 type RequireKeys<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 type InitOptions = RequireKeys<Options, 'rules'>;
@@ -89,14 +90,14 @@ export default class SwupFragmentPlugin extends PluginBase {
 	/**
 	 * Get the fragment visit object for a given route
 	 */
-	getFragmentVisit(route: Route): FragmentVisit | undefined {
+	getFragmentVisit(route: Route, visit?: Visit): FragmentVisit | undefined {
 		const rule = getFirstMatchingRule(route, this.rules);
 
 		// Bail early if no rule matched
 		if (!rule) return;
 
 		// Get containers that should be replaced for this visit
-		const containers = getContainersForVisit(route, rule.containers, this.logger);
+		const containers = getFragmentVisitContainers(route, rule.containers, visit, this.logger);
 		// Bail early if there are no containers to be replaced for this visit
 		if (!containers.length) return;
 

--- a/src/inc/Logger.ts
+++ b/src/inc/Logger.ts
@@ -6,17 +6,16 @@ const wrapInEscapeSequence = (s: string, open: number, close: number): string =>
 	if (s == null) return s;
 	return `\x1b[${open}m${String(s)}\x1b[${close}m`;
 };
+
 /**
- * @see https://github.com/lzwme/console-log-colors/blob/56a41b352bf9ed327cc864f588b831d92ee6390e/src/index.js#L4C3-L4C16
+ * Color Codes:
+ * @see https://github.com/lzwme/console-log-colors/blob/56a41b352bf9ed327cc864f588b831d92ee6390e/src/index.js
  */
 const bold = (s: string): string => wrapInEscapeSequence(s, 1, 22);
-/**
- * @see https://github.com/lzwme/console-log-colors/blob/56a41b352bf9ed327cc864f588b831d92ee6390e/src/index.js#L23
- */
-const redBright = (s: string): string => wrapInEscapeSequence(s, 91, 39);
+const purple = (s: string): string => wrapInEscapeSequence(s, 94, 39);
 
 const prepare = (s: string): string => `🧩 ${bold(s)}`;
-export const highlight = (s: string): string => redBright(s);
+export const highlight = (s: string): string => purple(s);
 
 /**
  * A slim wrapper around console statements

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -126,7 +126,7 @@ export default class ParsedRule {
 	validateFragmentSelectorForMatch(selector: string): true | Error {
 		if (!document.querySelector(selector)) {
 			// prettier-ignore
-			return new Error(`skipping rule since ${highlight(selector)} doesn't exist in document`);
+			return new Error(`skipping rule since ${highlight(selector)} doesn't exist in the current document`);
 		}
 		if (!queryFragmentElement(selector, this.swup)) {
 			// prettier-ignore

--- a/src/inc/ParsedRule.ts
+++ b/src/inc/ParsedRule.ts
@@ -1,7 +1,7 @@
 import Swup, { matchPath, classify, Location } from 'swup';
 import type { Path } from 'swup';
 import type { Route } from './defs.js';
-import { dedupe, fragmentIsOutOfBounds, queryFragmentElement } from './functions.js';
+import { dedupe, queryFragmentElement } from './functions.js';
 import Logger, { highlight } from './Logger.js';
 import { __DEV__ } from './env.js';
 import type SwupFragmentPlugin from '../SwupFragmentPlugin.js';
@@ -75,6 +75,7 @@ export default class ParsedRule {
 	 *
 	 * - only IDs are allowed
 	 * - no nested selectors
+	 * - no fragments outside of swup's default containers
 	 */
 	validateSelector(selector: string): true | Error {
 		if (!selector.startsWith('#')) {
@@ -85,10 +86,8 @@ export default class ParsedRule {
 			return new Error(`fragment selectors must not be nested: ${selector}`);
 		}
 
-		if (fragmentIsOutOfBounds(selector, this.swup)) {
-			return new Error(
-				`${highlight(selector)} is outside of swup's default containers`
-			);
+		if (document.querySelector(selector) && !queryFragmentElement(selector, this.swup)) {
+			return new Error(`${highlight(selector)} is outside of swup's default containers`);
 		}
 
 		return true;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -55,6 +55,7 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 		if (!fragment) {
 			if (__DEV__) {
 				logger?.log(
+					// prettier-ignore
 					`ignoring ${highlight(`[${targetAttribute}="${selector}"]`)} since ${highlight(selector)} is missing`
 				);
 			}

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -130,14 +130,14 @@ export const getFragmentVisitContainers = (
 		const el = document.querySelector<FragmentElement>(selector);
 
 		if (!el) {
-			if (__DEV__) logger?.log(`fragment "${selector}" missing in current document`);
+			if (__DEV__) logger?.log(`${highlight(selector)} missing in current document`);
 			return false;
 		}
 
-		if (fragmentIsOutOfBounds(selector, swup)) {
+		if (!queryFragmentElement(selector, swup)) {
 			if (__DEV__) {
 				// prettier-ignore
-				logger?.error(`ignoring ${highlight(selector)} as it is outside of swup's default containers`);
+				logger?.error(`${highlight(selector)} is outside of swup's default containers`);
 			}
 			return false;
 		}
@@ -370,7 +370,10 @@ export function adjustVisitScroll(fragmentVisit: FragmentVisit, scroll: VisitScr
 }
 
 /**
- * Queries a fragment element, only looking inside swup's containers
+ * Queries a fragment element. Needs to be either:
+ *
+ * - one of swup's default containers
+ * - inside of one of swup's default containers
  */
 export function queryFragmentElement(fragmentSelector: string, swup: Swup): FragmentElement | null {
 	for (const containerSelector of swup.options.containers) {
@@ -381,14 +384,4 @@ export function queryFragmentElement(fragmentSelector: string, swup: Swup): Frag
 		if (fragment) return fragment;
 	}
 	return null;
-}
-
-/**
- * Checks if a fragment element is outside of a swup's main containers
- */
-export function fragmentIsOutOfBounds(selector: string, swup: Swup): boolean {
-	/** Only check if the element exists at all */
-	if (!document.querySelector(selector)) return false;
-
-	return !queryFragmentElement(selector, swup);
 }

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -1,4 +1,4 @@
-import { Location } from 'swup';
+import Swup, { Location } from 'swup';
 import type { Visit, VisitScroll } from 'swup';
 import type { default as FragmentPlugin } from '../SwupFragmentPlugin.js';
 import type { Route, FragmentVisit, FragmentElement } from './defs.js';
@@ -118,7 +118,7 @@ function prepareFragmentElements({ rules, swup, logger }: FragmentPlugin): void 
 export const getFragmentVisitContainers = (
 	route: Route,
 	selectors: string[],
-	visit?: Visit,
+	swup: Swup,
 	logger?: Logger
 ) => {
 	const isReload = isEqualUrl(route.from, route.to);
@@ -131,10 +131,10 @@ export const getFragmentVisitContainers = (
 			return false;
 		}
 
-		if (elementIsOutOfBounds(el, visit)) {
+		if (fragmentIsOutOfBounds(selector, swup)) {
 			if (__DEV__) {
 				// prettier-ignore
-				logger?.warn(`ignoring fragment ${highlight(selector)} as it is outside of the visit's default containers:`, el);
+				logger?.warn(`ignoring fragment ${highlight(selector)} as it is outside of swup's default containers:`, el);
 			}
 			return false;
 		}
@@ -361,13 +361,10 @@ export function adjustVisitScroll(fragmentVisit: FragmentVisit, scroll: VisitScr
 }
 
 /**
- * Checks if a fragment element is inside of a visit's main containers
- *
- * Note: This check is not fully bullet-proof, as it only checks if
- * any an element's parents match the one of the selectors. But it
- * should catch most cases.
+ * Checks if a fragment element is outside of a swup's main containers
  */
-function elementIsOutOfBounds(el: FragmentElement, visit?: Visit): boolean {
-	if (!visit) return false;
-	return !visit.containers.some((selector) => el.closest(selector) !== null);
+function fragmentIsOutOfBounds(fragmentSelector: string, swup: Swup): boolean {
+	return !swup.options.containers.find(containerSelector => {
+		return document.querySelector(containerSelector)?.querySelector(fragmentSelector);
+	});
 }

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -53,7 +53,11 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 
 		const fragment = document.querySelector(selector) as FragmentElement;
 		if (!fragment) {
-			if (__DEV__) logger?.warn(`no element found for [${targetAttribute}="${selector}"]`);
+			if (__DEV__) {
+				logger?.log(
+					`ignoring ${highlight(`[${targetAttribute}="${selector}"]`)} since ${highlight(selector)} is missing`
+				);
+			}
 			return;
 		}
 

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -343,7 +343,9 @@ export function shouldSkipAnimation({ swup }: FragmentPlugin): boolean {
 	if (!fragmentVisit) return false;
 
 	return fragmentVisit.containers.every((selector) => {
-		return document.querySelector<FragmentElement>(selector)?.tagName?.toLowerCase() === 'template';
+		return (
+			document.querySelector<FragmentElement>(selector)?.tagName?.toLowerCase() === 'template'
+		);
 	});
 }
 
@@ -372,9 +374,10 @@ export function adjustVisitScroll(fragmentVisit: FragmentVisit, scroll: VisitScr
  */
 export function queryFragmentElement(fragmentSelector: string, swup: Swup): FragmentElement | null {
 	for (const containerSelector of swup.options.containers) {
-		const fragment = document
-			.querySelector(containerSelector)
-			?.querySelector<FragmentElement>(fragmentSelector);
+		const container = document.querySelector(containerSelector);
+		if (container?.matches(fragmentSelector)) return container;
+
+		const fragment = container?.querySelector<FragmentElement>(fragmentSelector);
 		if (fragment) return fragment;
 	}
 	return null;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -133,7 +133,7 @@ export const getFragmentVisitContainers = (
 		if (elementIsOutOfBounds(el, visit)) {
 			if (__DEV__) {
 				// prettier-ignore
-				logger?.warn(`ignoring fragment ${highlight(selector)} as it is outside of swup's default containers:`, el);
+				logger?.warn(`ignoring fragment ${highlight(selector)} as it is outside of the visit's default containers:`, el);
 			}
 			return false;
 		}

--- a/src/inc/handlers.ts
+++ b/src/inc/handlers.ts
@@ -35,7 +35,7 @@ export const onVisitStart: Handler<'visit:start'> = async function (this: Fragme
 	const route = getRoute(visit);
 	if (!route) return;
 
-	const fragmentVisit = this.getFragmentVisit(route);
+	const fragmentVisit = this.getFragmentVisit(route, visit);
 
 	/**
 	 * Bail early if the current route doesn't match


### PR DESCRIPTION
**Description**

I recently got bitten by the fact that I had fragments defined that were outside of swup's `options.containers`. This lead to hard-to-understand weirdness between normal and fragment visits.

This PR adds validation so that each fragment for a visit must meet one of these two rules:

1. It matches one of swup's default containers
2. It's a descendant of one of swup's default containers

Otherwise the fragment rule will be ignored for the current visit.

**How to test**: 

Markup:

```html
<body>
  <div id="my-test-fragment"></div>
  <div id="swup"><!-- main container --></div>
</body>
```

JS:

```js
new SwupFragmentPlugin({
	rules: [
		{
			from: '(.*)',
			to: '(.*)',
			containers: ['#my-test-fragment'],
		},
		// ... your other rules
	],
	debug: true,
});
```


**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated
- [x] Includes version bump and changelog update 
