### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,24 @@ html.is-animating .transition-main {
 
 ## Options
 
-```typescript
+### Type `Rule`
+
+```js
+export type Rule = {
+  from: string | string[];
+  to: string | string[];
+  containers: string[];
+  name?: string;
+  scroll?: boolean | string;
+  focus?: boolean | string;
+};
+```
+
+### Type `Options`
+
+```js
 export type Options = {
-  rules: Array<{
-    from: string | string[];
-    to: string | string[];
-    containers: string[];
-    name?: string;
-    scroll?: boolean | string;
-    focus?: boolean | string;
-  }>;
+  rules: Rule[];
   debug?: boolean;
 };
 ```
@@ -462,7 +470,7 @@ document.querySelectorAll('a[href]').forEach((el) => {
 
 ### `swup.prependFragmentRule(rule)`
 
-Prepends a [rule](#rules) to the array of rules.
+Prepends a [rule](#type-rule) to the array of rules.
 
 ```js
 swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
@@ -470,7 +478,7 @@ swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] }
 
 ### `swup.appendFragmentRule(rule)`
 
-Appends a [rule](#rules) to the array of rules.
+Appends a [rule](#type-rule) to the array of rules.
 
 ```js
 swup.prependFragmentRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat'] });

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The rule's `from`/`to` paths are converted to a regular expression by [path-to-r
     {
       from: ['/users', '/users/:filter?'],
       to: ['/users', '/users/:filter?'],
-      containers: ['#user-list'],
+      containers: ['#user-list']
     }
   ];
 }
@@ -196,7 +196,7 @@ Required, Type: `string[]` – Selectors of containers to be replaced if the vis
 **Notes**
 
 - **only IDs and no nested selectors are allowed**. `#my-element` is valid, while
-`.my-element` or `#wrap #child` both will throw an error.
+  `.my-element` or `#wrap #child` both will throw an error.
 - if **any** of the selectors in `containers` doesn't return a match in the current document, the rule will be skipped.
 - Fragment elements **must either match a swup container or be a descendant of one of them**
 
@@ -384,7 +384,9 @@ This will work fine, until you apply a `transform` to one of the modal's parent 
 
 ```css
 html.is-changing .transition-main {
-  transition: opacity 250ms, transform 250ms;
+  transition:
+    opacity 250ms,
+    transform 250ms;
 }
 html.is-animating .transition-main {
   opacity: 0;
@@ -429,3 +431,31 @@ The first `<main>` element in a document will be considered the main content by 
 **Cons**:
 
 - Wrapping your `<main>` content inside a `<dialog>` will produce [semantically incorrect markup](https://stackoverflow.com/a/75007908/586823). We still think it's the cleanest approach for now, until the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) reaches [wider browser support](https://caniuse.com/?search=popover).
+
+## Methods on the swup instance
+
+The plugin adds a few methods to the swup instance:
+
+### `getFragmentVisit(route)`
+
+Get the fragment visit for a given route. Example:
+
+```js
+const rules = [
+  // ...
+];
+const swup = new Swup({ plugins: [new SwupFragmentPlugin({ rules })] });
+/**
+ * Get information about which containers will
+ * be replaced when hovering over links:
+ */
+document.querySelectorAll('a[href]').forEach((el) => {
+  el.addEventListener('mouseenter', () => {
+    const fragmentVisit = swup.getFragmentVisit?.({
+      from: window.location.href,
+      to: el.href
+    });
+    console.log(`will replace ${fragmentVisit?.containers || swup.options.containers}`);
+  });
+});
+```

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ The first `<main>` element in a document will be considered the main content by 
 
 The plugin adds a few methods to the swup instance:
 
-### `getFragmentVisit({ from, to })
+### `swup.getFragmentVisit(route)`
 
 Get information about the fragment visit for a given route. Returns either `FragmentVisit` or `undefined`.
 
@@ -460,7 +460,7 @@ document.querySelectorAll('a[href]').forEach((el) => {
 });
 ```
 
-### `prependFragmentRule(rule)`
+### `swup.prependFragmentRule(rule)`
 
 Prepends a [rule](#rules) to the array of rules.
 
@@ -468,7 +468,7 @@ Prepends a [rule](#rules) to the array of rules.
 swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
 ```
 
-### `appendFragmentRule(rule)`
+### `swup.appendFragmentRule(rule)`
 
 Appends a [rule](#rules) to the array of rules.
 

--- a/README.md
+++ b/README.md
@@ -441,26 +441,29 @@ The first `<main>` element in a document will be considered the main content by 
 
 - Wrapping your `<main>` content inside a `<dialog>` will produce [semantically incorrect markup](https://stackoverflow.com/a/75007908/586823). We still think it's the cleanest approach for now, until the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) reaches [wider browser support](https://caniuse.com/?search=popover).
 
-## Methods on the swup instance
+## API methods
 
-The plugin adds a few methods to the swup instance:
+Fragment plugin provides a few API functions for advanced use cases. To be able to access those, you'll need to keep a reference to the plugin during instanciation:
 
-### `swup.getFragmentVisit(route)`
+```js
+const fragmentPlugin = new SwupFragmentPlugin({ rules });
+const swup = new Swup({ plugins: [ fragmentPlugin ] });
+/** You can now call the plugin's public API, for example: */
+fragmentPlugin.getFragmentVisit(route);
+```
+
+### `getFragmentVisit(route)`
 
 Get information about the fragment visit for a given route. Returns either `FragmentVisit` or `undefined`.
 
 ```js
-const rules = [
-  // ...
-];
-const swup = new Swup({ plugins: [new SwupFragmentPlugin({ rules })] });
 /**
  * Get information about which containers will
  * be replaced when hovering over links:
  */
 document.querySelectorAll('a[href]').forEach((el) => {
   el.addEventListener('mouseenter', () => {
-    const fragmentVisit = swup.getFragmentVisit?.({
+    const fragmentVisit = fragmentPlugin.getFragmentVisit({
       from: window.location.href, // the current URL
       to: el.href // the URL of the link
     });
@@ -469,18 +472,30 @@ document.querySelectorAll('a[href]').forEach((el) => {
 });
 ```
 
-### `swup.prependFragmentRule(rule)`
+### `prependRule(rule)`
 
 Prepends a [rule](#type-signature-rule) to the array of rules.
 
 ```js
-swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
+fragmentPlugin.prependRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
 ```
 
-### `swup.appendFragmentRule(rule)`
+### `appendRule(rule)`
 
 Appends a [rule](#type-signature-rule) to the array of rules.
 
 ```js
-swup.prependFragmentRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat'] });
+fragmentPlugin.prependRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat'] });
 ```
+
+### `getRules()`
+
+Get a [clone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) of all registered fragment rules
+
+```js
+console.log(fragmentPlugin.getRules());
+```
+
+### `setRules(rules)`
+
+Overwrite all fragment rules with the provided rules.

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ The reason for this is that a CSS `transform` establishes a [containing block fo
 You have two options to fix this:
 
 1. Don't apply CSS `transform`s to any of the parents of a modal
-2. Use `<detail open>` for the modal:
+2. Use `<dialog open>` for the modal:
 
 ```diff
 - <main id="overlay" class="modal">

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ fragmentPlugin.prependRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat']
 
 ### `getRules()`
 
-Get a [clone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) of all registered fragment rules
+Get a **clone** of all registered fragment rules
 
 ```js
 console.log(fragmentPlugin.getRules());
@@ -497,7 +497,7 @@ console.log(fragmentPlugin.getRules());
 
 ### `setRules(rules)`
 
-Overwrite all fragment rules with the provided rules. This methods provides the lowest-level access to the rules. For example, you could use it to remove all rules with the name  `foobar`:
+Overwrite all fragment rules with the provided rules. This methods provides the lowest-level access to the rules. For example, you could use it to remove all rules with the name `foobar`:
 
 ```js
 fragmentPlugin.setRules(

--- a/README.md
+++ b/README.md
@@ -147,7 +147,17 @@ html.is-animating .transition-main {
 
 ## Options
 
-### Type `Rule`
+
+### Type Signature: `Options`
+
+```js
+export type Options = {
+  rules: Rule[];
+  debug?: boolean;
+};
+```
+
+### Type Signature: `Rule`
 
 ```js
 export type Rule = {
@@ -157,15 +167,6 @@ export type Rule = {
   name?: string;
   scroll?: boolean | string;
   focus?: boolean | string;
-};
-```
-
-### Type `Options`
-
-```js
-export type Options = {
-  rules: Rule[];
-  debug?: boolean;
 };
 ```
 
@@ -470,7 +471,7 @@ document.querySelectorAll('a[href]').forEach((el) => {
 
 ### `swup.prependFragmentRule(rule)`
 
-Prepends a [rule](#type-rule) to the array of rules.
+Prepends a [rule](#type-signature-rule) to the array of rules.
 
 ```js
 swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
@@ -478,7 +479,7 @@ swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] }
 
 ### `swup.appendFragmentRule(rule)`
 
-Appends a [rule](#type-rule) to the array of rules.
+Appends a [rule](#type-signature-rule) to the array of rules.
 
 ```js
 swup.prependFragmentRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat'] });

--- a/README.md
+++ b/README.md
@@ -459,3 +459,19 @@ document.querySelectorAll('a[href]').forEach((el) => {
   });
 });
 ```
+
+### `prependFragmentRule(rule)`
+
+Prepends a [rule](#rules) to the array of rules.
+
+```js
+swup.prependFragmentRule({ from: '/foo/', to: '/bar/', containers: ['#foobar'] });
+```
+
+### `appendFragmentRule(rule)`
+
+Appends a [rule](#rules) to the array of rules.
+
+```js
+swup.prependFragmentRule({ from: '/baz/', to: '/bat/', containers: ['#bazbat'] });
+```

--- a/README.md
+++ b/README.md
@@ -500,8 +500,5 @@ console.log(fragmentPlugin.getRules());
 Overwrite all fragment rules with the provided rules. This methods provides the lowest-level access to the rules. For example, you could use it to remove all rules with the name `foobar`:
 
 ```js
-fragmentPlugin.setRules(
-  fragmentPlugin.getRules()
-    .filter((rule) => rule.name !== 'foobar')
-);
+fragmentPlugin.setRules(fragmentPlugin.getRules().filter((rule) => rule.name !== 'foobar'));
 ```

--- a/README.md
+++ b/README.md
@@ -436,9 +436,9 @@ The first `<main>` element in a document will be considered the main content by 
 
 The plugin adds a few methods to the swup instance:
 
-### `getFragmentVisit(route)`
+### `getFragmentVisit({ from, to })
 
-Get the fragment visit for a given route. Example:
+Get information about the fragment visit for a given route. Returns either `FragmentVisit` or `undefined`.
 
 ```js
 const rules = [
@@ -452,8 +452,8 @@ const swup = new Swup({ plugins: [new SwupFragmentPlugin({ rules })] });
 document.querySelectorAll('a[href]').forEach((el) => {
   el.addEventListener('mouseenter', () => {
     const fragmentVisit = swup.getFragmentVisit?.({
-      from: window.location.href,
-      to: el.href
+      from: window.location.href, // the current URL
+      to: el.href // the URL of the link
     });
     console.log(`will replace ${fragmentVisit?.containers || swup.options.containers}`);
   });

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ html.is-animating .transition-main {
 
 ## Options
 
-
 ### Type Signature: `Options`
 
 ```js
@@ -447,7 +446,7 @@ Fragment plugin provides a few API functions for advanced use cases. To be able 
 
 ```js
 const fragmentPlugin = new SwupFragmentPlugin({ rules });
-const swup = new Swup({ plugins: [ fragmentPlugin ] });
+const swup = new Swup({ plugins: [fragmentPlugin] });
 /** You can now call the plugin's public API, for example: */
 fragmentPlugin.getFragmentVisit(route);
 ```
@@ -498,4 +497,11 @@ console.log(fragmentPlugin.getRules());
 
 ### `setRules(rules)`
 
-Overwrite all fragment rules with the provided rules.
+Overwrite all fragment rules with the provided rules. This methods provides the lowest-level access to the rules. For example, you could use it to remove all rules with the name  `foobar`:
+
+```js
+fragmentPlugin.setRules(
+  fragmentPlugin.getRules()
+    .filter((rule) => rule.name !== 'foobar')
+);
+```


### PR DESCRIPTION
**Description**

Adds documentation for these API methods:

- [x] `getFragmentVisit`
- [x] `prependFragmentRule`
- [x] `appendFragmentRule`
- [x] `getFragmentRules`
- [x] `setFragmentRules`

[Link to the readme](https://github.com/swup/fragment-plugin/tree/feat/update-readme#api-methods)

**Drive-By**

Fixed typo 🫣: 
```diff
- <detail open>
+ <dialog open>
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required
