### PR TITLE
Prevent Escape key presses on `<dialog>` fragments

### DIFF
--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -33,6 +33,7 @@ function showDialogs({ logger }: FragmentPlugin): void {
 			el.__swupFragment.modalShown = true;
 			el.removeAttribute('open');
 			el.showModal?.();
+			el.addEventListener('keydown', (e) => e.key === 'Escape' && e.preventDefault());
 		});
 }
 


### PR DESCRIPTION
Related: #61 

**Description**

Prevent <kbd>Escape</kbd> key presses on `<dialog>` fragments. 

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)

