### PR TITLE
Add inherited action for automerging dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,8 @@
+name: Automerge Dependabot PRs
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    uses: swup/.github/.github/workflows/dependabot-automerge.yml@master
+    secrets: inherit


### PR DESCRIPTION
**Description**

~Let's see if this works. I have no experience with inherited actions~. There actually was no dependabot PR open for fragment-plugin. I tested this in [debug-plugin](https://github.com/swup/debug-plugin/pull/31) instead. Works nicely!

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
