### PR TITLE
fix: update link to fragment for same url

### DIFF
--- a/src/inc/defs.ts
+++ b/src/inc/defs.ts
@@ -7,7 +7,7 @@ export type Route = {
 };
 
 /** The interface for an augmented Fragment Element */
-export interface FragmentElement extends Element {
+export interface FragmentElement extends HTMLElement {
 	__swupFragment?: {
 		url?: string;
 		selector?: string;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -371,7 +371,7 @@ export function queryFragmentElement(
 ): FragmentElement | undefined {
 	for (const containerSelector of swup.options.containers) {
 		const container = document.querySelector(containerSelector);
-		if (container?.matches(fragmentSelector)) return container;
+		if (container?.matches(fragmentSelector)) return container as FragmentElement;
 
 		const fragment = container?.querySelector<FragmentElement>(fragmentSelector);
 		if (fragment) return fragment;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -45,7 +45,6 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 	const links = document.querySelectorAll<HTMLAnchorElement>(`a[${targetAttribute}]`);
 
 	links.forEach((el) => {
-		console.log({ el });
 		const selector = el.getAttribute(targetAttribute);
 		if (!selector) {
 			// prettier-ignore

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -45,6 +45,7 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 	const links = document.querySelectorAll<HTMLAnchorElement>(`a[${targetAttribute}]`);
 
 	links.forEach((el) => {
+		console.log({ el });
 		const selector = el.getAttribute(targetAttribute);
 		if (!selector) {
 			// prettier-ignore
@@ -73,7 +74,6 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 		if (isEqualUrl(fragmentUrl, swup.getCurrentUrl())) {
 			// prettier-ignore
 			if (__DEV__) logger?.warn(`The fragment URL of ${selector} is identical to the current URL. This could mean that [data-swup-fragment-url] needs to be provided by the server.`);
-			return;
 		}
 
 		el.href = fragmentUrl;


### PR DESCRIPTION
**Description**

Besides a warning if the URL of a fragment targeted by a `a[data-swup-link-to-fragment]` would already match the current url, that URL was also not being applied to the link. I see no reason why it shouldn't do so anyways. I currently have a more complex project where I needed this.

**Drive-By**

- extend `FragmentElement` from `HTMLElement` instead of `Element`

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
