### PR TITLE
Remove rules where `rule.from` and/or `rule.to` are empty

### DIFF
--- a/src/SwupFragmentPlugin.ts
+++ b/src/SwupFragmentPlugin.ts
@@ -6,7 +6,8 @@ import {
 	cleanupFragmentElements,
 	getFirstMatchingRule,
 	getFragmentVisitContainers,
-	cloneRules
+	cloneRules,
+	validateRules
 } from './inc/functions.js';
 import type { Options, Rule, Route, FragmentVisit } from './inc/defs.js';
 import * as handlers from './inc/handlers.js';
@@ -91,6 +92,7 @@ export default class SwupFragmentPlugin extends PluginBase {
 	 * @access public
 	 */
 	setRules(rules: Rule[]) {
+		rules = validateRules(rules);
 		this._rawRules = cloneRules(rules);
 		this._parsedRules = rules.map((rule) => this.parseRule(rule));
 		if (__DEV__) this.logger?.log('Updated fragment rules', this.getRules());

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -414,6 +414,28 @@ export function queryFragmentElement(
 }
 
 /**
+ * Validate rules and remove invalid ones
+ */
+export function validateRules(rules: Rule[]): Rule[] {
+	return rules
+		.map((rule) => {
+			if (isEmptyArray(rule.to)) rule.to = '';
+			if (isEmptyArray(rule.from)) rule.from = '';
+			return rule;
+		})
+		.filter((rule) => {
+			const { from, to } = rule;
+
+			if (!to || !from) {
+				console.error('rule.from and rule.to may not be empty:', rule);
+				return false;
+			}
+
+			return true;
+		});
+}
+
+/**
  * Clone fragment rules (replacement for `structuredClone`)
  */
 export function cloneRules(rules: Rule[]): Rule[] {
@@ -434,4 +456,11 @@ export function stubVisit(options: { from?: string; to: string }) {
 	const swup = new Swup();
 	// @ts-expect-error swup.createVisit is protected
 	return swup.createVisit(options);
+}
+
+/**
+ * Check if a value is an empty array
+ */
+export function isEmptyArray(value: any) {
+	return Array.isArray(value) && value.length === 0;
 }

--- a/tests/vitest/validateRules.test.ts
+++ b/tests/vitest/validateRules.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { validateRules } from '../../src/inc/functions.js';
 
 describe('validateRules()', () => {
-	it.only('should remove invalid rules', () => {
+	it('should remove invalid rules', () => {
 		expect(validateRules([{ from: '', to: '', containers: ['#foobar'] }])).toEqual([]);
 
 		expect(validateRules([{ from: '', to: 'bar', containers: ['#foobar'] }])).toEqual([]);

--- a/tests/vitest/validateRules.test.ts
+++ b/tests/vitest/validateRules.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { validateRules } from '../../src/inc/functions.js';
+
+describe('validateRules()', () => {
+	it.only('should remove invalid rules', () => {
+		expect(validateRules([{ from: '', to: '', containers: ['#foobar'] }])).toEqual([]);
+
+		expect(validateRules([{ from: '', to: 'bar', containers: ['#foobar'] }])).toEqual([]);
+
+		expect(validateRules([{ from: 'foo', to: '', containers: ['#foobar'] }])).toEqual([]);
+
+		expect(validateRules([{ from: [], to: 'bar', containers: ['#foobar'] }])).toEqual([]);
+
+		expect(validateRules([{ from: '', to: [], containers: ['#foobar'] }])).toEqual([]);
+
+		expect(validateRules([{ from: [], to: [], containers: ['#foobar'] }])).toEqual([]);
+	});
+});


### PR DESCRIPTION
**Description**

I just stumbled upon a case where a fragment rule always matched. Both `rule.from` as well as `rule.to` were empty arrays (dynamically generated by my CMS). Turns out `matchPath` always matches these:

```js
{
    from: [],
    to: [],
    containers: ["#main"],
    scroll: "#top",
    focus: false,
  }
```

This PR introduces a little validation function to remove these rules. Fragment plugin will also print an error to the console to make the user aware of the issue.

**Alternative**

This PR be pointing to an underlying issue with `matchPath`. Is there any scenario where that function should match if the url is empty (an empty string or array)? I don't think so. Then it would make more sense to fix this directly in swup core I think.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included