### PR TITLE
chore: hide badges on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Swup Fragment Plugin
 
-<!-- swup-docs-hide-start -->
+<!-- swup-docs-ignore-start -->
 
 [![npm version](https://img.shields.io/npm/v/@swup/fragment-plugin.svg)](https://www.npmjs.com/package/@swup/fragment-plugin)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/unit-tests.yml?branch=main&label=vitest)](https://github.com/swup/fragment-plugin/actions/workflows/unit-tests.yml)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/e2e-tests.yml?branch=main&label=playwright)](https://github.com/swup/fragment-plugin/actions/workflows/e2e-tests.yml)
 [![License](https://img.shields.io/github/license/swup/fragment-plugin.svg)](https://github.com/swup/fragment-plugin/blob/main/LICENSE)
 
-<!-- swup-docs-hide-end -->
+<!-- swup-docs-ignore-end -->
 
 A [swup](https://swup.js.org) plugin for dynamically replacing containers based on rules 🧩
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Swup Fragment Plugin
 
-<div class="shields">
+<!-- swup-docs-hide-start -->
 
 [![npm version](https://img.shields.io/npm/v/@swup/fragment-plugin.svg)](https://www.npmjs.com/package/@swup/fragment-plugin)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/unit-tests.yml?branch=main&label=vitest)](https://github.com/swup/fragment-plugin/actions/workflows/unit-tests.yml)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/e2e-tests.yml?branch=main&label=playwright)](https://github.com/swup/fragment-plugin/actions/workflows/e2e-tests.yml)
 [![License](https://img.shields.io/github/license/swup/fragment-plugin.svg)](https://github.com/swup/fragment-plugin/blob/main/LICENSE)
 
-</div>
+<!-- swup-docs-hide-end -->
 
 A [swup](https://swup.js.org) plugin for dynamically replacing containers based on rules 🧩
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 <div class="shields">
 
-<!--[![npm version](https://img.shields.io/npm/v/@swup/fragment-plugin.svg)](https://www.npmjs.com/package/@swup/fragment-plugin) -->
-
+[![npm version](https://img.shields.io/npm/v/@swup/fragment-plugin.svg)](https://www.npmjs.com/package/@swup/fragment-plugin)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/unit-tests.yml?branch=main&label=vitest)](https://github.com/swup/fragment-plugin/actions/workflows/unit-tests.yml)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/swup/fragment-plugin/e2e-tests.yml?branch=main&label=playwright)](https://github.com/swup/fragment-plugin/actions/workflows/e2e-tests.yml)
 [![License](https://img.shields.io/github/license/swup/fragment-plugin.svg)](https://github.com/swup/fragment-plugin/blob/main/LICENSE)


### PR DESCRIPTION
**Description**

Prepare badges to be hidden on the docs. 
Related discussion: https://github.com/swup/scroll-plugin/pull/90#discussion_r2144514218

Direct link to readme: https://github.com/swup/fragment-plugin/tree/chore/hide-badges-on-docs

**Turns out**: We already have a way to hide stuff from the docs:

```html
<!-- swup-docs-ignore-start -->
<p>Won't be rendered in the docs</p>
<!-- swup-docs-ignore-end -->
```

**Drive-By**

- Render a badge for the current npm version

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The documentation was updated as required
