### PR TITLE
Support multiple fragment selectors in `data-swup-link-to-fragment` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,15 @@ tracked URL of the fragment matching the selector provided by the attribute. The
   data-swup-link-to-fragment="#list">Close</a>
 ```
 
+The attribute also supports multiple selectors separated by commas, syncing to whichever fragment matches first.
+
+```diff
+<a
+  href="/users/"
++  data-swup-link-to-fragment="#main, #list"
+>Close</a>
+```
+
 ## Skip animations using `<template>`
 
 If all elements of a visit are `<template>` elements, the `out`/`in`-animation will automatically be skipped. This can come in handy for modals:

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -58,9 +58,12 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 
 		if (!fragment) {
 			if (__DEV__) {
+				const verb = fragmentSelectors.length > 1 ? 'are' : 'is';
+				const selectorDisplay = highlight(fragmentSelectors.join(', '));
+
 				logger?.log(
 					// prettier-ignore
-					`ignoring ${highlight(`[${targetAttribute}="${selectors}"]`)} as ${highlight(selectors)} is missing`
+					`ignoring ${highlight(`[${targetAttribute}="${selectors}"]`)} as ${selectorDisplay} ${verb} missing`
 				);
 			}
 			return;

--- a/src/inc/functions.ts
+++ b/src/inc/functions.ts
@@ -53,11 +53,7 @@ function handleLinksToFragments({ logger, swup }: FragmentPlugin): void {
 			return;
 		}
 
-		const fragmentSelectors = selectors
-			.trim()
-			.split(',')
-			.map((sel) => sel.trim());
-
+		const fragmentSelectors = parseLinkToFragmentAttribute(selectors);
 		const fragment = queryFragmentElementSelectorList(fragmentSelectors, swup);
 
 		if (!fragment) {
@@ -449,6 +445,18 @@ export function cloneRules(rules: Rule[]): Rule[] {
 		to: Array.isArray(rule.to) ? [...rule.to] : rule.to,
 		containers: [...rule.containers]
 	}));
+}
+
+/**
+ * Parses a fragment link attribute value into an array of fragment selectors
+ */
+export function parseLinkToFragmentAttribute(value: string): string[] {
+	const fragmentSelectors = value
+		.trim()
+		.split(',')
+		.map((sel) => sel.trim());
+
+	return fragmentSelectors;
 }
 
 /**

--- a/tests/vitest/queryFragmentElementSelectorList.test.ts
+++ b/tests/vitest/queryFragmentElementSelectorList.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { stubGlobalDocument } from './inc/helpers.js';
+import { queryFragmentElementSelectorList } from '../../src/inc/functions.js';
+import Swup from 'swup';
+
+describe('queryFragmentElementSelectorList()', () => {
+	it('should return first element when first selector matches', () => {
+		const swup = new Swup();
+		stubGlobalDocument(/*html*/ `
+			<div id="swup" class="transition-main">
+				<div id="fragment-1"></div>
+				<div id="fragment-2"></div>
+			</div>
+		`);
+
+		const result = queryFragmentElementSelectorList(['#fragment-2', '#fragment-1'], swup);
+		expect(result?.id).toBe('fragment-2');
+	});
+
+	it('should fallthrough selectors until first match', () => {
+		const swup = new Swup();
+		stubGlobalDocument(/*html*/ `
+			<div id="swup" class="transition-main">
+				<div id="fragment-2"></div>
+			</div>
+		`);
+
+		const result = queryFragmentElementSelectorList(['#fragment-1', '#fragment-2'], swup);
+		expect(result?.id).toBe('fragment-2');
+	});
+
+	it('should return undefined when no selectors match', () => {
+		const swup = new Swup();
+		stubGlobalDocument(/*html*/ `
+			<div id="swup" class="transition-main">
+				<div id="fragment-1"></div>
+				<div id="fragment-2"></div>
+			</div>
+		`);
+
+		const result = queryFragmentElementSelectorList(
+			['#non-existing', '#also-non-existing'],
+			swup
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it('should handle empty selectors', () => {
+		const swup = new Swup();
+		stubGlobalDocument(/*html*/ `
+			<div id="swup" class="transition-main">
+				<div id="fragment-1"></div>
+				<div id="fragment-2"></div>
+			</div>
+		`);
+
+		const result = queryFragmentElementSelectorList([], swup);
+		expect(result).toBeUndefined();
+	});
+});


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**
Adds support for multiple comma-separated fragment selectors in the `data-swup-link-to-fragment` attribute. Previously, only a single selector was supported. Now users can specify multiple selectors where the first matching element will be used for updating the fragment link. 

This is usefull for modals shown on-top of content which renders another swup fragment (filtered or paginated lists for example). 

```html
<!-- Before -->
<dialog data-swup-link-to-fragment="#filtered-list">[…]</dialog>

<!-- Possible with this PR -->
<dialog data-swup-link-to-fragment="#filtered-list, #main">[…]</dialog>
```

**TODO**
- [x] Add better debug messages reflecting which fragment was resolved for `data-swup-link-to-fragment`.

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
