### PR TITLE
Setup trusted publising

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,11 @@ name: Publish package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 
 jobs:
   publish-npm:
@@ -13,9 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Setup trusted publishing to npm as described here: https://docs.npmjs.com/trusted-publishers

## Steps
- [x] Visit https://www.npmjs.com/package/@swup/fragment-plugin > Settings, fill out the "Trusted Publisher" section
- [x] Update the publish workflow:
  - [x] remove the token
  - [x] add `id-token: write` permissions
