### PR TITLE
Fix debug logging in firefox

### DIFF
--- a/src/inc/Logger.ts
+++ b/src/inc/Logger.ts
@@ -1,7 +1,6 @@
 import { __TEST__ } from './env.js';
 
 const isFirefox = navigator.userAgent.includes('Firefox');
-console.log({ isFirefox });
 
 /**
  * Wrap a string in an escape sequence

--- a/src/inc/Logger.ts
+++ b/src/inc/Logger.ts
@@ -1,10 +1,14 @@
 import { __TEST__ } from './env.js';
+
+const isFirefox = navigator.userAgent.includes('Firefox');
+console.log({ isFirefox });
+
 /**
  * Wrap a string in an escape sequence
  * @see https://stackoverflow.com/a/68373080/586823
  */
 const wrapInEscapeSequence = (s: string, open: number, close: number): string => {
-	if (s == null) return s;
+	if (isFirefox || s == null) return s;
 	return `\x1b[${open}m${String(s)}\x1b[${close}m`;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ declare module 'swup' {
 	export interface Visit {
 		fragmentVisit?: FragmentVisit;
 	}
-	export interface CacheData {
+	export interface PageData {
 		fragmentHtml?: string;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ declare module 'swup' {
 	export interface Visit {
 		fragmentVisit?: FragmentVisit;
 	}
-	export interface PageData {
+	export interface CacheData {
 		fragmentHtml?: string;
 	}
 }


### PR DESCRIPTION
Fixes #100 

**Description**

The Firefox console doesn't support ANSI escape sequences, breaking the debug formatting. The easy fix is to not style logging in Firefox, at all.

**Drive-by**

- ~Augment `PageData` instead of `CacheData`, since swup [recently changed `CacheData` from an augmentable interface to a plain type alias (`type CacheData = PageData`)](https://github.com/swup/swup/commit/f4c1572cf59e86b57778351f42cc802643301ee9)~ Reverting in [swup core](https://github.com/swup/swup/pull/1050)

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
